### PR TITLE
전략 패턴 DI 적용

### DIFF
--- a/src/main/java/me/minkh/app/service/engraving/converter/CombatStatsConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/CombatStatsConverter.java
@@ -1,39 +1,26 @@
 package me.minkh.app.service.engraving.converter;
 
+import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.dto.engraving.request.CombatStat;
 import me.minkh.app.service.engraving.converter.strategy.combatstats.CombatStatsConverterStrategy;
-import me.minkh.app.service.engraving.converter.strategy.combatstats.CriticalStrategy;
-import me.minkh.app.service.engraving.converter.strategy.combatstats.SwiftnessStrategy;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static me.minkh.app.service.LostArkConstants.CRITICAL;
-import static me.minkh.app.service.LostArkConstants.SWIFTNESS;
-
+@RequiredArgsConstructor
 @Service
 public class CombatStatsConverter {
 
-    private final Map<String, CombatStatsConverterStrategy> strategyContext = new HashMap<>();
-
-    public CombatStatsConverter() {
-        strategyContext.put(CRITICAL, new CriticalStrategy());
-        strategyContext.put(SWIFTNESS, new SwiftnessStrategy());
-    }
+    private final List<CombatStatsConverterStrategy> strategies;
 
     public CombatAttributeDto convert(List<CombatStat> combatStats) {
         CombatAttributeDto result = new CombatAttributeDto();
         for (CombatStat combatStat : combatStats) {
-            String type = combatStat.getType();
-            int value = combatStat.getValue();
-
-            CombatStatsConverterStrategy strategy = strategyContext.get(type);
-            if (strategy == null) continue;
-
-            strategy.updateCombatAttributeDto(result, value);
+            for (CombatStatsConverterStrategy strategy : strategies) {
+                if (!strategy.supports(combatStat.getType())) continue;
+                strategy.updateCombatAttributeDto(result, combatStat.getValue());
+            }
         }
         return result;
     }

--- a/src/main/java/me/minkh/app/service/engraving/converter/ElixirConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/ElixirConverter.java
@@ -1,38 +1,29 @@
 package me.minkh.app.service.engraving.converter;
 
-import me.minkh.app.dto.engraving.request.Elixir;
+import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import me.minkh.app.dto.engraving.request.Elixir;
 import me.minkh.app.service.engraving.converter.strategy.elixir.ElixirConverterStrategy;
-import me.minkh.app.service.engraving.converter.strategy.elixir.ExpertStrategy;
-import me.minkh.app.service.engraving.converter.strategy.elixir.VanGuardStrategy;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
-import static me.minkh.app.service.LostArkConstants.*;
+import static me.minkh.app.service.LostArkConstants.ELIXIR_TO_ATTACK_INCREASE_MAP;
 
+@RequiredArgsConstructor
 @Service
 public class ElixirConverter {
 
-    private final Map<String, ElixirConverterStrategy> strategyContext = new HashMap<>();
-
-    public ElixirConverter() {
-        strategyContext.put(VANGUARD, new VanGuardStrategy());
-        strategyContext.put(EXPERT, new ExpertStrategy());
-    }
+    private final List<ElixirConverterStrategy> strategies;
 
     public CombatAttributeDto convert(Elixir elixir) {
         CombatAttributeDto result = new CombatAttributeDto();
-
         int headOffensePower = elixir.getHeadOffensePower();
         result.setAttackIncrease(ELIXIR_TO_ATTACK_INCREASE_MAP.get(headOffensePower));
-
-        ElixirConverterStrategy strategy = this.strategyContext.get(elixir.getType());
-        if (strategy != null && strategy.supports(elixir.getLevel())) {
+        for (ElixirConverterStrategy strategy : strategies) {
+            if (!strategy.supports(elixir.getType(), elixir.getLevel())) continue;
             strategy.updateCombatAttributeDto(result);
         }
-
         return result;
     }
 }

--- a/src/main/java/me/minkh/app/service/engraving/converter/EngravingsConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/EngravingsConverter.java
@@ -1,35 +1,26 @@
 package me.minkh.app.service.engraving.converter;
 
-import me.minkh.app.dto.engraving.request.Engraving;
+import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.service.engraving.converter.strategy.engravings.AdrenalineStrategy;
-import me.minkh.app.service.engraving.converter.strategy.engravings.CursedDollStrategy;
+import me.minkh.app.dto.engraving.request.Engraving;
 import me.minkh.app.service.engraving.converter.strategy.engravings.EngravingsConverterStrategy;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static me.minkh.app.service.LostArkConstants.*;
-
+@RequiredArgsConstructor
 @Service
 public class EngravingsConverter {
 
-    private final Map<String, EngravingsConverterStrategy> strategyContext = new HashMap<>();
-
-    public EngravingsConverter() {
-        strategyContext.put(CURSED_DOLL, new CursedDollStrategy());
-        strategyContext.put(ADRENALINE, new AdrenalineStrategy());
-    }
+    private final List<EngravingsConverterStrategy> strategies;
 
     public CombatAttributeDto convert(List<Engraving> engravings) {
         CombatAttributeDto result = new CombatAttributeDto();
         for (Engraving engraving : engravings) {
-            EngravingsConverterStrategy strategy = this.strategyContext.get(engraving.getName());
-
-            if (strategy == null) continue;
-            strategy.updateCombatAttributeDto(result, engraving.getLevel());
+            for (EngravingsConverterStrategy strategy : this.strategies) {
+                if (!strategy.supports(engraving.getName())) continue;
+                strategy.updateCombatAttributeDto(result, engraving.getLevel());
+            }
         }
         return result;
     }

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/CombatStatsConverterStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/CombatStatsConverterStrategy.java
@@ -4,6 +4,8 @@ import me.minkh.app.dto.engraving.CombatAttributeDto;
 
 public interface CombatStatsConverterStrategy {
 
+    boolean supports(String type);
+
     void updateCombatAttributeDto(CombatAttributeDto dto, int value);
 
 }

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/CriticalStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/CriticalStrategy.java
@@ -1,10 +1,18 @@
 package me.minkh.app.service.engraving.converter.strategy.combatstats;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
+import static me.minkh.app.service.LostArkConstants.CRITICAL;
 import static me.minkh.app.service.LostArkConstants.CRITICAL_HIT_RATE_COEFFICIENT;
 
+@Component
 public class CriticalStrategy implements CombatStatsConverterStrategy {
+
+    @Override
+    public boolean supports(String type) {
+        return type.equals(CRITICAL);
+    }
 
     public void updateCombatAttributeDto(CombatAttributeDto dto, int value) {
         double criticalHitRate = value * CRITICAL_HIT_RATE_COEFFICIENT;

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/SwiftnessStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/combatstats/SwiftnessStrategy.java
@@ -1,10 +1,18 @@
 package me.minkh.app.service.engraving.converter.strategy.combatstats;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
 import static me.minkh.app.service.LostArkConstants.SPEED_INCREASE_COEFFICIENT;
+import static me.minkh.app.service.LostArkConstants.SWIFTNESS;
 
+@Component
 public class SwiftnessStrategy implements CombatStatsConverterStrategy {
+
+    @Override
+    public boolean supports(String type) {
+        return type.equals(SWIFTNESS);
+    }
 
     public void updateCombatAttributeDto(CombatAttributeDto dto, int value) {
         double speedIncrease = value * SPEED_INCREASE_COEFFICIENT / 100;

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/ElixirConverterStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/ElixirConverterStrategy.java
@@ -4,7 +4,7 @@ import me.minkh.app.dto.engraving.CombatAttributeDto;
 
 public interface ElixirConverterStrategy {
 
-    boolean supports(int level);
+    boolean supports(String type, int level);
 
     void updateCombatAttributeDto(CombatAttributeDto dto);
 }

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/ExpertStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/ExpertStrategy.java
@@ -1,14 +1,17 @@
 package me.minkh.app.service.engraving.converter.strategy.elixir;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
+import static me.minkh.app.service.LostArkConstants.EXPERT;
 import static me.minkh.app.service.LostArkConstants.EXPERT_CRITICAL_HIT_RATE;
 
+@Component
 public class ExpertStrategy implements ElixirConverterStrategy {
 
     @Override
-    public boolean supports(int level) {
-        return level == 40;
+    public boolean supports(String type, int level) {
+        return type.equals(EXPERT) && level == 40;
     }
 
     @Override

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/VanGuardStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/elixir/VanGuardStrategy.java
@@ -1,14 +1,18 @@
 package me.minkh.app.service.engraving.converter.strategy.elixir;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
+import static me.minkh.app.service.LostArkConstants.VANGUARD;
 import static me.minkh.app.service.LostArkConstants.VANGUARD_ATTACK_INCREASE;
 
+@Component
 public class VanGuardStrategy implements ElixirConverterStrategy {
 
     @Override
-    public boolean supports(int level) {
-        return level == 35 || level == 40;
+    public boolean supports(String type, int level) {
+        return (type.equals(VANGUARD) && level == 35) ||
+               (type.equals(VANGUARD) && level == 40);
     }
 
     @Override

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/AdrenalineStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/AdrenalineStrategy.java
@@ -1,10 +1,17 @@
 package me.minkh.app.service.engraving.converter.strategy.engravings;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
 import static me.minkh.app.service.LostArkConstants.*;
 
+@Component
 public class AdrenalineStrategy implements EngravingsConverterStrategy {
+
+    @Override
+    public boolean supports(String name) {
+        return name.equals(ADRENALINE);
+    }
 
     @Override
     public void updateCombatAttributeDto(CombatAttributeDto dto, int level) {

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/CursedDollStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/CursedDollStrategy.java
@@ -1,10 +1,18 @@
 package me.minkh.app.service.engraving.converter.strategy.engravings;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import org.springframework.stereotype.Component;
 
+import static me.minkh.app.service.LostArkConstants.CURSED_DOLL;
 import static me.minkh.app.service.LostArkConstants.CURSED_DOLL_TO_ATTACK_INCREASE_MAP;
 
+@Component
 public class CursedDollStrategy implements EngravingsConverterStrategy {
+
+    @Override
+    public boolean supports(String name) {
+        return name.equals(CURSED_DOLL);
+    }
 
     @Override
     public void updateCombatAttributeDto(CombatAttributeDto dto, int level) {

--- a/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/EngravingsConverterStrategy.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/strategy/engravings/EngravingsConverterStrategy.java
@@ -4,6 +4,8 @@ import me.minkh.app.dto.engraving.CombatAttributeDto;
 
 public interface EngravingsConverterStrategy {
 
+    boolean supports(String name);
+
     void updateCombatAttributeDto(CombatAttributeDto dto, int level);
 
 }

--- a/src/test/java/me/minkh/app/service/engraving/converter/ArtifactConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/ArtifactConverterTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class LostArkEquipmentResponseConverterTest {
+class ArtifactConverterTest {
 
     @Autowired
     ArtifactConverter artifactConverter;

--- a/src/test/java/me/minkh/app/service/engraving/converter/CombatStatsConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/CombatStatsConverterTest.java
@@ -4,14 +4,20 @@ import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.dto.engraving.request.CombatStat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LostArkProfilesResponseConverterTest {
+@SpringBootTest
+@ActiveProfiles("test")
+class CombatStatsConverterTest {
 
-    CombatStatsConverter combatStatsConverter = new CombatStatsConverter();
+    @Autowired
+    CombatStatsConverter combatStatsConverter;
 
     @DisplayName("치명이 1,000 일 때는 치명타 적중률이 35.7이다.")
     @Test

--- a/src/test/java/me/minkh/app/service/engraving/converter/ElixirConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/ElixirConverterTest.java
@@ -4,12 +4,18 @@ import me.minkh.app.dto.engraving.request.Elixir;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
+@ActiveProfiles("test")
 class ElixirConverterTest {
 
-    ElixirConverter elixirConverter = new ElixirConverter();
+    @Autowired
+    ElixirConverter elixirConverter;
 
     @DisplayName("머리 공격력 증가량 테스트")
     @Test

--- a/src/test/java/me/minkh/app/service/engraving/converter/EngravingsConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/EngravingsConverterTest.java
@@ -1,24 +1,29 @@
 package me.minkh.app.service.engraving.converter;
 
-import me.minkh.app.dto.engraving.request.Engraving;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
+import me.minkh.app.dto.engraving.request.Engraving;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.stream.Stream;
 
+import static me.minkh.app.service.LostArkConstants.ADRENALINE;
+import static me.minkh.app.service.LostArkConstants.CURSED_DOLL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class LostArkEngravingsResponseConverterTest {
+@SpringBootTest
+@ActiveProfiles("test")
+class EngravingsConverterTest {
 
-    private static final String CURSED_DOLL = "저주받은 인형";
-    private static final String ADRENALINE = "아드레날린";
-
-    EngravingsConverter engravingsConverter = new EngravingsConverter();
+    @Autowired
+    EngravingsConverter engravingsConverter;
 
     @ParameterizedTest(name = "저주받은 인형 : {0}, 아드레날린 : {1}, 공격력 증가 : {2}")
     @MethodSource("method")


### PR DESCRIPTION
해당 PR에서는 전략 패턴에 DI를 적용하였습니다.

기존에 적용한 전략 패턴의 문제점은 새로운 전략이 생성될 때 마다 `Converter`로 들어가 새로운 전략을 등록해 주어야 했습니다.

가령, 아래와 같은 형식입니다.

```java
  public CombatStatsConverter() {
      strategyContext.put(CRITICAL, new CriticalStrategy());
      strategyContext.put(SWIFTNESS, new SwiftnessStrategy());
      strategyContext.put(NEWCONST, new NewStrategy()); // 새로운 전략 등록
  }
```

전략들을 `@Component` 어노테이션을 적용하여 빈으로 등록한 뒤 의존성 주입을 통해 받아오도록 리팩터링 하였습니다.

기대효과는 `Converter` 클래스의 변경 없이 새로운 전략만 추가하면 기능이 추가될 수 있을 것 같습니다.