### PR TITLE
Spring Boot Actuator, Prometheus 의존성 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
             cd /home/ec2-user
             docker-compose pull app
             docker-compose up -d app
+            docker image prune -a -f
 
       # GitHub Actions VM 환경의 IP를 인바운드 규칙에서 제거한다.
       - name: Remove GitHub Actions IP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
           host: ${{ secrets.EC2_SSH_HOST_NAME }}
           username: ${{ secrets.EC2_SSH_USER }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          script: ./deploy.sh
+          script: |
+            cd /home/ec2-user
+            docker-compose pull app
+            docker-compose up -d app
 
       # GitHub Actions VM 환경의 IP를 인바운드 규칙에서 제거한다.
       - name: Remove GitHub Actions IP

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 변경점 1

애플리케이션 성능 모니터링(Application Performance Monitoring, APM) 환경 구축을 위한 의존성을 추가하였습니다.

- Spring Boot Actuator
- Prometheus

자세한 내용은 [#25] 에 작성하였습니다.

그라파나에서 제공하는 아래의 대시보드 중 하나를 사용하고 싶은데, 프리티어의 사양 때문에 테스트 결과 대시보드 창 로딩이 안 되어 어떠한 화면을 제공해야 할 지 고민 중에 있습니다. 대시보드를 직접 만들어야 한다면 학습에 대한 시간도 상당히 걸릴듯 합니다.

- [JVM (Micrometer)](https://grafana.com/grafana/dashboards/4701-jvm-micrometer/)
- [Spring Boot 2.1 System Monitor](https://grafana.com/grafana/dashboards/11378-justai-system-monitor/)

## 변경점 2

docker-compose 생성에 따른 배포에 오류가 생겨 workflows를 일부 수정하였습니다.