### PR TITLE
InfoService 로직 수정

### DIFF
--- a/src/main/java/me/minkh/app/AppApplication.java
+++ b/src/main/java/me/minkh/app/AppApplication.java
@@ -1,32 +1,16 @@
 package me.minkh.app;
 
 import lombok.RequiredArgsConstructor;
-import me.minkh.app.domain.engraving.Artifact;
-import me.minkh.app.domain.engraving.ArtifactRepository;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import static me.minkh.app.service.LostArkConstants.*;
-
 @EnableJpaAuditing
 @RequiredArgsConstructor
 @SpringBootApplication
-public class AppApplication implements CommandLineRunner {
-
-    private final ArtifactRepository artifactRepository;
+public class AppApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AppApplication.class, args);
-    }
-
-    @Override
-    public void run(String... args) {
-        this.artifactRepository.save(new Artifact(NIGHTMARE, 0, 0, 0, 0));
-        this.artifactRepository.save(new Artifact(SALVATION, 0, 0, 0, 0));
-        this.artifactRepository.save(new Artifact(DOMINION, 0, 0, 0, 0));
-        this.artifactRepository.save(new Artifact(ENTROPY, 22, 65, 0, 0));
-        this.artifactRepository.save(new Artifact(HALLUCINATION, 28, 0, 0, 0));
     }
 }

--- a/src/main/java/me/minkh/app/config/ConfigConst.java
+++ b/src/main/java/me/minkh/app/config/ConfigConst.java
@@ -2,5 +2,9 @@ package me.minkh.app.config;
 
 public final class ConfigConst {
 
+    private ConfigConst() {
+
+    }
+
     public static final String SESSION = "SESSION";
 }

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
         // csrf 옵션 disable
         http.csrf(AbstractHttpConfigurer::disable);
         // AUTH_LIST의 경로 외 나머지 옵션은 인증이 필요 없음
-        http.authorizeHttpRequests((authorize) ->
+        http.authorizeHttpRequests(authorize ->
                 authorize
                         .requestMatchers(AUTH_LIST).authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/accounts").authenticated()

--- a/src/main/java/me/minkh/app/controller/InfoController.java
+++ b/src/main/java/me/minkh/app/controller/InfoController.java
@@ -1,11 +1,13 @@
 package me.minkh.app.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import me.minkh.app.config.ConfigConst;
 import me.minkh.app.dto.info.InfoResponse;
 import me.minkh.app.service.info.InfoService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @RestController
@@ -18,7 +20,10 @@ public class InfoController {
     }
 
     @GetMapping("/info/{characterName}")
-    public InfoResponse info(@PathVariable("characterName") String characterName) {
-        return this.infoService.info(characterName);
+    public InfoResponse info(
+            @PathVariable("characterName") String characterName,
+            @SessionAttribute(ConfigConst.SESSION) Long accountId
+    ) {
+        return this.infoService.info(characterName, accountId);
     }
 }

--- a/src/main/java/me/minkh/app/controller/LoginController.java
+++ b/src/main/java/me/minkh/app/controller/LoginController.java
@@ -8,6 +8,6 @@ public class LoginController {
 
     @GetMapping("/login")
     public String login() {
-        return "/login";
+        return "login";
     }
 }

--- a/src/main/java/me/minkh/app/domain/account/Account.java
+++ b/src/main/java/me/minkh/app/domain/account/Account.java
@@ -1,5 +1,6 @@
 package me.minkh.app.domain.account;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class Account extends BaseTimeEntity {
 
     private String name;
 
+    @Column(columnDefinition = "TEXT")
     private String apiKey;
 
     public Account update(String email, String name) {

--- a/src/main/java/me/minkh/app/domain/account/AccountRepository.java
+++ b/src/main/java/me/minkh/app/domain/account/AccountRepository.java
@@ -11,4 +11,6 @@ public interface AccountRepository extends Repository<Account, Long> {
     Optional<Account> findById(Long id);
 
     Optional<Account> findByEmail(String email);
+
+    void deleteAll();
 }

--- a/src/main/java/me/minkh/app/domain/account/AccountRepository.java
+++ b/src/main/java/me/minkh/app/domain/account/AccountRepository.java
@@ -3,7 +3,6 @@ package me.minkh.app.domain.account;
 import org.springframework.data.repository.Repository;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface AccountRepository extends Repository<Account, Long> {
 

--- a/src/main/java/me/minkh/app/domain/engraving/ArtifactRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/ArtifactRepository.java
@@ -9,4 +9,6 @@ public interface ArtifactRepository extends Repository<Artifact, Long> {
     void save(Artifact artifact);
 
     Optional<Artifact> findByName(String name);
+
+    void deleteAll();
 }

--- a/src/main/java/me/minkh/app/dto/account/AccountResponse.java
+++ b/src/main/java/me/minkh/app/dto/account/AccountResponse.java
@@ -10,12 +10,15 @@ public class AccountResponse {
 
     private final Long id;
 
+    private final String email;
+
     private final String name;
 
     private final String apiKey;
 
     public AccountResponse(Account account) {
         this.id = account.getId();
+        this.email = account.getEmail();
         this.name = account.getName();
         this.apiKey = account.getApiKey();
     }

--- a/src/main/java/me/minkh/app/dto/account/UpdateApiKeyRequest.java
+++ b/src/main/java/me/minkh/app/dto/account/UpdateApiKeyRequest.java
@@ -1,9 +1,13 @@
 package me.minkh.app.dto.account;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 
+@AllArgsConstructor
+@Builder
 @Getter
 public class UpdateApiKeyRequest {
 

--- a/src/main/java/me/minkh/app/service/LostArkApiService.java
+++ b/src/main/java/me/minkh/app/service/LostArkApiService.java
@@ -24,9 +24,6 @@ public class LostArkApiService {
     @Value("${lost-ark-api-url}")
     private String lostArkApiUrl;
 
-    @Value("${lost-ark-api-token}")
-    private String lostArkApiToken;
-
     private static final String BEARER = "Bearer ";
 
     private final RestTemplate restTemplate;
@@ -38,22 +35,22 @@ public class LostArkApiService {
         this.objectMapper = objectMapper;
     }
 
-    public LostArkProfilesResponse getProfiles(String characterName) {
-        return callApi(characterName, "/profiles", LostArkProfilesResponse.class);
+    public LostArkProfilesResponse getProfiles(String characterName, String apiKey) {
+        return callApi(characterName, "/profiles", apiKey, LostArkProfilesResponse.class);
     }
 
-    public LostArkEngravingsResponse getEngravings(String characterName) {
-        return callApi(characterName, "/engravings", LostArkEngravingsResponse.class);
+    public LostArkEngravingsResponse getEngravings(String characterName, String apiKey) {
+        return callApi(characterName, "/engravings", apiKey, LostArkEngravingsResponse.class);
     }
 
-    public LostArkEquipmentResponse[] getEquipment(String characterName) {
-        return callApi(characterName, "/equipment", LostArkEquipmentResponse[].class);
+    public LostArkEquipmentResponse[] getEquipment(String characterName, String apiKey) {
+        return callApi(characterName, "/equipment", apiKey, LostArkEquipmentResponse[].class);
     }
 
-    private <T> T callApi(String characterName, String path, Class<T> clazz) {
+    private <T> T callApi(String characterName, String path, String apikey, Class<T> clazz) {
         String url = getUrl(characterName, path);
 
-        HttpEntity<String> httpEntity = getHttpEntity();
+        HttpEntity<String> httpEntity = getHttpEntity(apikey);
 
         String body = this.restTemplate.exchange(url, HttpMethod.GET, httpEntity, String.class).getBody();
         if (Objects.equals(body, "null")) {
@@ -68,9 +65,9 @@ public class LostArkApiService {
         }
     }
 
-    private HttpEntity<String> getHttpEntity() {
+    private HttpEntity<String> getHttpEntity(String apiKey) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, BEARER + this.lostArkApiToken);
+        headers.set(HttpHeaders.AUTHORIZATION, BEARER + apiKey);
         return new HttpEntity<>(headers);
     }
 

--- a/src/main/java/me/minkh/app/service/info/InfoService.java
+++ b/src/main/java/me/minkh/app/service/info/InfoService.java
@@ -36,13 +36,13 @@ public class InfoService {
             throw new IllegalArgumentException("API키 업데이트가 필요합니다.");
         }
 
-        LostArkEquipmentResponse[] equipment = this.lostArkApiService.getEquipment(characterName);
+        LostArkEquipmentResponse[] equipment = this.lostArkApiService.getEquipment(characterName, apiKey);
         String artifact = this.lostArkEquipmentResponseConverter.convert(equipment);
 
-        LostArkProfilesResponse lostArkProfilesResponse = this.lostArkApiService.getProfiles(characterName);
+        LostArkProfilesResponse lostArkProfilesResponse = this.lostArkApiService.getProfiles(characterName, apiKey);
         List<CombatStat> combatStats = this.lostArkProfilesResponseConverter.convert(lostArkProfilesResponse);
 
-        LostArkEngravingsResponse engravings = this.lostArkApiService.getEngravings(characterName);
+        LostArkEngravingsResponse engravings = this.lostArkApiService.getEngravings(characterName, apiKey);
         List<Engraving> engravingResponseDtos = this.lostArkEngravingsResponseConverter.convert(engravings);
 
         return new InfoResponse(

--- a/src/main/java/me/minkh/app/service/info/InfoService.java
+++ b/src/main/java/me/minkh/app/service/info/InfoService.java
@@ -1,9 +1,11 @@
 package me.minkh.app.service.info;
 
 import lombok.RequiredArgsConstructor;
+import me.minkh.app.domain.account.Account;
+import me.minkh.app.domain.account.AccountRepository;
+import me.minkh.app.dto.info.CombatStat;
 import me.minkh.app.dto.info.Engraving;
 import me.minkh.app.dto.info.InfoResponse;
-import me.minkh.app.dto.info.CombatStat;
 import me.minkh.app.dto.lostark.LostArkEngravingsResponse;
 import me.minkh.app.dto.lostark.LostArkEquipmentResponse;
 import me.minkh.app.dto.lostark.LostArkProfilesResponse;
@@ -23,8 +25,17 @@ public class InfoService {
     private final LostArkEquipmentResponseConverter lostArkEquipmentResponseConverter;
     private final LostArkProfilesResponseConverter lostArkProfilesResponseConverter;
     private final LostArkEngravingsResponseConverter lostArkEngravingsResponseConverter;
+    private final AccountRepository accountRepository;
 
-    public InfoResponse info(String characterName) {
+    public InfoResponse info(String characterName, Long accountId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException(accountId + "은 올바르지 않은 요청입니다."));
+
+        String apiKey = account.getApiKey();
+        if (apiKey == null) {
+            throw new IllegalArgumentException("API키 업데이트가 필요합니다.");
+        }
+
         LostArkEquipmentResponse[] equipment = this.lostArkApiService.getEquipment(characterName);
         String artifact = this.lostArkEquipmentResponseConverter.convert(equipment);
 

--- a/src/test/java/me/minkh/app/service/InfoServiceTest.java
+++ b/src/test/java/me/minkh/app/service/InfoServiceTest.java
@@ -58,9 +58,9 @@ class InfoServiceTest {
         );
 
         // when
-        when(lostArkApiService.getEquipment(characterName)).thenReturn(lostArkEquipmentResponse);
-        when(lostArkApiService.getEngravings(characterName)).thenReturn(lostArkEngravingsResponse);
-        when(lostArkApiService.getProfiles(characterName)).thenReturn(lostArkProfilesResponse);
+        when(lostArkApiService.getEquipment(characterName, savedAccount.getApiKey())).thenReturn(lostArkEquipmentResponse);
+        when(lostArkApiService.getEngravings(characterName, savedAccount.getApiKey())).thenReturn(lostArkEngravingsResponse);
+        when(lostArkApiService.getProfiles(characterName, savedAccount.getApiKey())).thenReturn(lostArkProfilesResponse);
         InfoResponse result = homeService.info(characterName, savedAccount.getId());
 
         // then

--- a/src/test/java/me/minkh/app/service/InfoServiceTest.java
+++ b/src/test/java/me/minkh/app/service/InfoServiceTest.java
@@ -1,6 +1,8 @@
 package me.minkh.app.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import me.minkh.app.domain.account.Account;
+import me.minkh.app.domain.account.AccountRepository;
 import me.minkh.app.dto.info.InfoResponse;
 import me.minkh.app.dto.lostark.LostArkEngravingsResponse;
 import me.minkh.app.dto.lostark.LostArkEquipmentResponse;
@@ -16,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,6 +35,9 @@ class InfoServiceTest {
     @Autowired
     InfoService homeService;
 
+    @Autowired
+    AccountRepository accountRepository;
+
     @MockBean
     LostArkApiService lostArkApiService;
 
@@ -43,12 +49,19 @@ class InfoServiceTest {
         LostArkEquipmentResponse[] lostArkEquipmentResponse = getEquipmentDto();
         LostArkEngravingsResponse lostArkEngravingsResponse = getEngravingsDto();
         LostArkProfilesResponse lostArkProfilesResponse = getProfileDto();
+        Account savedAccount = accountRepository.save(
+                Account.builder()
+                        .email("test@test.com")
+                        .name("test")
+                        .apiKey(UUID.randomUUID().toString())
+                        .build()
+        );
 
         // when
         when(lostArkApiService.getEquipment(characterName)).thenReturn(lostArkEquipmentResponse);
         when(lostArkApiService.getEngravings(characterName)).thenReturn(lostArkEngravingsResponse);
         when(lostArkApiService.getProfiles(characterName)).thenReturn(lostArkProfilesResponse);
-        InfoResponse result = homeService.info(characterName);
+        InfoResponse result = homeService.info(characterName, savedAccount.getId());
 
         // then
         assertThat(result.getArtifact()).isEqualTo("사멸");

--- a/src/test/java/me/minkh/app/service/LostArkApiServiceMockTest.java
+++ b/src/test/java/me/minkh/app/service/LostArkApiServiceMockTest.java
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,6 +36,8 @@ class LostArkApiServiceMockTest {
 
     String path = "src/test/java/me/minkh/app/";
 
+    String apiKey = UUID.randomUUID().toString();
+
     @DisplayName("프로필 조회에 성공하는 테스트")
     @Test
     void getProfiles() throws IOException {
@@ -44,7 +47,7 @@ class LostArkApiServiceMockTest {
 
         // when
         when(restTemplate.exchange(anyString(), any(), any(), eq(String.class))).thenReturn(ResponseEntity.ok(body));
-        LostArkProfilesResponse lostArkProfilesResponse = this.lostArkApiService.getProfiles(characterName);
+        LostArkProfilesResponse lostArkProfilesResponse = this.lostArkApiService.getProfiles(characterName, apiKey);
 
         // then
         assertThat(lostArkProfilesResponse.getStats().size()).isEqualTo(8);
@@ -60,7 +63,7 @@ class LostArkApiServiceMockTest {
 
         // when
         when(restTemplate.exchange(anyString(), any(), any(), eq(String.class))).thenReturn(ResponseEntity.ok(body));
-        LostArkEngravingsResponse engravings = this.lostArkApiService.getEngravings(characterName);
+        LostArkEngravingsResponse engravings = this.lostArkApiService.getEngravings(characterName, apiKey);
 
         // then
         assertThat(engravings.getEffects().size()).isEqualTo(6);
@@ -75,7 +78,7 @@ class LostArkApiServiceMockTest {
 
         // when
         when(restTemplate.exchange(anyString(), any(), any(), eq(String.class))).thenReturn(ResponseEntity.ok(body));
-        LostArkEquipmentResponse[] lostArkEquipmentResponses = this.lostArkApiService.getEquipment(characterName);
+        LostArkEquipmentResponse[] lostArkEquipmentResponses = this.lostArkApiService.getEquipment(characterName, apiKey);
 
         // then
         assertThat(lostArkEquipmentResponses.length).isEqualTo(16);
@@ -91,7 +94,7 @@ class LostArkApiServiceMockTest {
         // when & then
         when(restTemplate.exchange(anyString(), any(), any(), eq(String.class))).thenReturn(ResponseEntity.ok("null"));
 
-        assertThatThrownBy(() -> this.lostArkApiService.getProfiles(characterName))
+        assertThatThrownBy(() -> this.lostArkApiService.getProfiles(characterName, apiKey))
                 .isInstanceOf(CharacterNotFoundException.class)
                 .hasMessage(characterName + "에 해당하는 캐릭터가 없습니다.");
     }
@@ -105,7 +108,7 @@ class LostArkApiServiceMockTest {
         // when & then
         when(restTemplate.exchange(anyString(), any(), any(), eq(String.class))).thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
 
-        assertThatThrownBy(() -> this.lostArkApiService.getProfiles(characterName))
+        assertThatThrownBy(() -> this.lostArkApiService.getProfiles(characterName, apiKey))
                 .isInstanceOf(HttpClientErrorException.class);
     }
 }

--- a/src/test/java/me/minkh/app/service/account/AccountServiceTest.java
+++ b/src/test/java/me/minkh/app/service/account/AccountServiceTest.java
@@ -1,0 +1,73 @@
+package me.minkh.app.service.account;
+
+import me.minkh.app.domain.account.Account;
+import me.minkh.app.domain.account.AccountRepository;
+import me.minkh.app.dto.account.AccountResponse;
+import me.minkh.app.dto.account.UpdateApiKeyRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AccountServiceTest {
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    AccountService accountService;
+
+    @AfterEach
+    void afterEach() {
+        this.accountRepository.deleteAll();
+    }
+
+    @DisplayName("API Key 업데이트 성공 테스트")
+    @Test
+    void updateApiKeySuccess() {
+        // given
+        String apiKey = UUID.randomUUID().toString();
+        UpdateApiKeyRequest request = UpdateApiKeyRequest
+                .builder()
+                .apiKey(apiKey)
+                .build();
+
+        Account savedAccount = accountRepository.save(Account.builder()
+                .name("test")
+                .email("test@test.com")
+                .apiKey(apiKey)
+                .build());
+
+        // when
+        AccountResponse accountResponse = accountService.updateApiKey(request, savedAccount.getId());
+
+        // then
+        assertThat(accountResponse.getId()).isEqualTo(savedAccount.getId());
+        assertThat(accountResponse.getEmail()).isEqualTo(savedAccount.getEmail());
+        assertThat(accountResponse.getName()).isEqualTo(savedAccount.getName());
+        assertThat(accountResponse.getApiKey()).isEqualTo(savedAccount.getApiKey());
+    }
+
+    @DisplayName("API Key 업데이트 실패 테스트")
+    @Test
+    void updateApiKeyFail() {
+        // given
+        UpdateApiKeyRequest request = UpdateApiKeyRequest
+                .builder()
+                .apiKey(UUID.randomUUID().toString())
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> accountService.updateApiKey(request, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/me/minkh/app/service/engraving/converter/ArtifactConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/ArtifactConverterTest.java
@@ -1,8 +1,12 @@
 package me.minkh.app.service.engraving.converter;
 
 
+import me.minkh.app.domain.engraving.Artifact;
+import me.minkh.app.domain.engraving.ArtifactRepository;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import static me.minkh.app.service.LostArkConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -19,6 +24,23 @@ class ArtifactConverterTest {
 
     @Autowired
     ArtifactConverter artifactConverter;
+
+    @Autowired
+    ArtifactRepository artifactRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        this.artifactRepository.save(new Artifact(NIGHTMARE, 0, 0, 0, 0));
+        this.artifactRepository.save(new Artifact(SALVATION, 0, 0, 0, 0));
+        this.artifactRepository.save(new Artifact(DOMINION, 0, 0, 0, 0));
+        this.artifactRepository.save(new Artifact(ENTROPY, 22, 65, 0, 0));
+        this.artifactRepository.save(new Artifact(HALLUCINATION, 28, 0, 0, 0));
+    }
+
+    @AfterEach
+    void afterEach() {
+        this.artifactRepository.deleteAll();
+    }
 
     @DisplayName("악몽, 구원, 지배")
     @ParameterizedTest


### PR DESCRIPTION
해당 PR에서는 아래의 작업을 진행하였습니다.

- application.properties에서 받아온 apiKey를 이용하여 API를 호출하던 부분을 Account의 apiKey를 이용하도록 변경하였습니다.
- 로직 변경 및 추가에 따른 테스트 코드를 수정, 추가하였습니다.
- apiKey 길이가 600이 넘어가서 타입을 TEXT로 변경하였습니다.
- CommandLineRunner 코드를 제거하고 테스트가 깨지지 않도록 Artifact 저장 코드는 테스트 코드로 이동하였습니다.