### PR TITLE
SecurityContext를 활용한 리팩터링 및 회원가입, 이메일 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/me/minkh/app/AppApplication.java
+++ b/src/main/java/me/minkh/app/AppApplication.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @RequiredArgsConstructor
 @SpringBootApplication

--- a/src/main/java/me/minkh/app/config/AppConfig.java
+++ b/src/main/java/me/minkh/app/config/AppConfig.java
@@ -2,6 +2,8 @@ package me.minkh.app.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -10,5 +12,10 @@ public class AppConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
+++ b/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
@@ -1,0 +1,76 @@
+package me.minkh.app.config.auth;
+
+import lombok.Getter;
+import me.minkh.app.domain.account.Account;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class AccountAdapter implements OAuth2User, UserDetails {
+
+    private final Account account;
+    private OAuth2User oAuth2User;
+
+    public AccountAdapter(Account account) {
+        this.account = account;
+    }
+
+    public AccountAdapter(Account account, OAuth2User oAuth2User) {
+        this.account = account;
+        this.oAuth2User = oAuth2User;
+    }
+
+    // OAuth2User
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.oAuth2User.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return this.oAuth2User.getAttribute("name");
+    }
+
+    // UserDetails
+
+    @Override
+    public String getPassword() {
+        return this.account.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return this.account.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/me/minkh/app/config/auth/CurrentId.java
+++ b/src/main/java/me/minkh/app/config/auth/CurrentId.java
@@ -1,0 +1,15 @@
+package me.minkh.app.config.auth;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "account.id")
+public @interface CurrentId {
+
+}

--- a/src/main/java/me/minkh/app/config/auth/MyOAuth2UserService.java
+++ b/src/main/java/me/minkh/app/config/auth/MyOAuth2UserService.java
@@ -1,8 +1,6 @@
 package me.minkh.app.config.auth;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import me.minkh.app.config.ConfigConst;
 import me.minkh.app.domain.account.Account;
 import me.minkh.app.domain.account.AccountRepository;
 import me.minkh.app.dto.account.Attribute;
@@ -17,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class MyOAuth2UserService extends DefaultOAuth2UserService {
 
     private final AccountRepository accountRepository;
-    private final HttpSession httpSession;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -30,9 +27,6 @@ public class MyOAuth2UserService extends DefaultOAuth2UserService {
                 .orElse(attribute.toEntity());
         this.accountRepository.save(account);
 
-        // 세션 저장, ID만 저장한 뒤, 필요하면 꺼내서 쓴다.
-        httpSession.setAttribute(ConfigConst.SESSION, account.getId());
-
-        return oAuth2User;
+        return new AccountAdapter(account, oAuth2User);
     }
 }

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor
@@ -22,12 +23,20 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // csrf 옵션 disable
         http.csrf(AbstractHttpConfigurer::disable);
+
         // AUTH_LIST의 경로 외 나머지 옵션은 인증이 필요 없음
         http.authorizeHttpRequests(authorize ->
                 authorize
                         .requestMatchers(AUTH_LIST).authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/accounts").authenticated()
                         .anyRequest().permitAll());
+
+        // Basic Authentication 활성화
+        http.httpBasic(h -> h.realmName("App"));
+
+        // 세션 활성화
+        http.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
+
         // OAuth2
         http.oauth2Login(o -> o.loginPage("/login").userInfoEndpoint(u -> u.userService(oAuth2UserService)));
         return http.build();

--- a/src/main/java/me/minkh/app/controller/AccountController.java
+++ b/src/main/java/me/minkh/app/controller/AccountController.java
@@ -2,8 +2,7 @@ package me.minkh.app.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import me.minkh.app.config.ConfigConst;
-import me.minkh.app.domain.account.Account;
+import me.minkh.app.config.auth.CurrentId;
 import me.minkh.app.dto.account.AccountRequest;
 import me.minkh.app.dto.account.AccountResponse;
 import me.minkh.app.dto.account.UpdateApiKeyRequest;
@@ -18,7 +17,7 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping
-    public Account save(@Valid @RequestBody AccountRequest accountRequest) {
+    public AccountResponse save(@Valid @RequestBody AccountRequest accountRequest) {
         return this.accountService.save(accountRequest);
     }
 
@@ -30,7 +29,8 @@ public class AccountController {
     @PatchMapping
     public AccountResponse updateApiKey(
             @Valid @RequestBody UpdateApiKeyRequest request,
-            @SessionAttribute(ConfigConst.SESSION) Long id) {
-        return this.accountService.updateApiKey(request, id);
+            @CurrentId Long accountId
+    ) {
+        return this.accountService.updateApiKey(request, accountId);
     }
 }

--- a/src/main/java/me/minkh/app/controller/InfoController.java
+++ b/src/main/java/me/minkh/app/controller/InfoController.java
@@ -1,13 +1,12 @@
 package me.minkh.app.controller;
 
 import lombok.extern.slf4j.Slf4j;
-import me.minkh.app.config.ConfigConst;
+import me.minkh.app.config.auth.CurrentId;
 import me.minkh.app.dto.info.InfoResponse;
 import me.minkh.app.service.info.InfoService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @RestController
@@ -22,7 +21,7 @@ public class InfoController {
     @GetMapping("/info/{characterName}")
     public InfoResponse info(
             @PathVariable("characterName") String characterName,
-            @SessionAttribute(ConfigConst.SESSION) Long accountId
+            @CurrentId Long accountId
     ) {
         return this.infoService.info(characterName, accountId);
     }

--- a/src/main/java/me/minkh/app/controller/VerificationCodeController.java
+++ b/src/main/java/me/minkh/app/controller/VerificationCodeController.java
@@ -1,0 +1,31 @@
+package me.minkh.app.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckResponse;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendResponse;
+import me.minkh.app.service.account.VerificationCodeService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/verification-code")
+public class VerificationCodeController {
+
+    private final VerificationCodeService verificationCodeService;
+
+    @PostMapping("/send")
+    public VerificationCodeSendResponse send(@Valid @RequestBody VerificationCodeSendRequest request) {
+        return this.verificationCodeService.send(request);
+    }
+
+    @PostMapping("/check")
+    public VerificationCodeCheckResponse check(@Valid @RequestBody VerificationCodeCheckRequest request) {
+        return this.verificationCodeService.check(request);
+    }
+}

--- a/src/main/java/me/minkh/app/domain/account/Account.java
+++ b/src/main/java/me/minkh/app/domain/account/Account.java
@@ -15,12 +15,17 @@ import me.minkh.app.domain.model.BaseTimeEntity;
 @Entity
 public class Account extends BaseTimeEntity {
 
+    @Column(unique = true)
     private String email;
 
     private String name;
 
+    private String password;
+
     @Column(columnDefinition = "TEXT")
     private String apiKey;
+
+    private boolean isEmailVerified;
 
     public Account update(String email, String name) {
         this.email = email;
@@ -31,6 +36,10 @@ public class Account extends BaseTimeEntity {
     public Account updateApiKey(String apiKey) {
         this.apiKey = apiKey;
         return this;
+    }
+
+    public void verifiedEmail() {
+        this.isEmailVerified = true;
     }
 }
 

--- a/src/main/java/me/minkh/app/domain/account/VerificationCode.java
+++ b/src/main/java/me/minkh/app/domain/account/VerificationCode.java
@@ -1,0 +1,42 @@
+package me.minkh.app.domain.account;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.minkh.app.domain.model.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class VerificationCode extends BaseEntity {
+
+    private String code;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Account account;
+
+    private LocalDateTime expiredDate;
+
+    public void update(String code, Account account, LocalDateTime expiredDate) {
+        this.code = code;
+        this.account = account;
+        this.expiredDate = expiredDate;
+    }
+
+    public boolean isCodeMisMatch(String code) {
+        return !this.code.equals(code);
+    }
+
+    public boolean isExpired() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.isAfter(this.expiredDate);
+    }
+}

--- a/src/main/java/me/minkh/app/domain/account/VerificationCodeRepository.java
+++ b/src/main/java/me/minkh/app/domain/account/VerificationCodeRepository.java
@@ -1,0 +1,14 @@
+package me.minkh.app.domain.account;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface VerificationCodeRepository extends Repository<VerificationCode, Long> {
+
+    VerificationCode save(VerificationCode verificationCode);
+
+    Optional<VerificationCode> findByAccount(Account account);
+
+    void deleteAll();
+}

--- a/src/main/java/me/minkh/app/dto/account/AccountRequest.java
+++ b/src/main/java/me/minkh/app/dto/account/AccountRequest.java
@@ -2,26 +2,36 @@ package me.minkh.app.dto.account;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import me.minkh.app.domain.account.Account;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+@AllArgsConstructor
+@Builder
 @Getter
 public class AccountRequest {
-
-    @NotBlank
-    private String name;
 
     @NotBlank
     @Email
     private String email;
 
-    private String apiKey;
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String password;
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
+    }
 
     public Account toEntity() {
         return Account.builder()
                 .name(this.name)
                 .email(this.email)
-                .apiKey(this.apiKey)
+                .password(this.password)
                 .build();
     }
 }

--- a/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeCheckRequest.java
+++ b/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeCheckRequest.java
@@ -1,19 +1,24 @@
-package me.minkh.app.dto.account;
+package me.minkh.app.dto.account.verificationcode;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
-public class UpdateApiKeyRequest {
+public class VerificationCodeCheckRequest {
 
     @NotBlank
-    @Length(min = 20)
-    private String apiKey;
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
 }
+
+

--- a/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeCheckResponse.java
+++ b/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeCheckResponse.java
@@ -1,0 +1,15 @@
+package me.minkh.app.dto.account.verificationcode;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationCodeCheckResponse {
+
+    boolean success;
+
+    public VerificationCodeCheckResponse(boolean success) {
+        this.success = success;
+    }
+}
+
+

--- a/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeSendRequest.java
+++ b/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeSendRequest.java
@@ -1,19 +1,21 @@
-package me.minkh.app.dto.account;
+package me.minkh.app.dto.account.verificationcode;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
-public class UpdateApiKeyRequest {
+public class VerificationCodeSendRequest {
 
     @NotBlank
-    @Length(min = 20)
-    private String apiKey;
+    @Email
+    private String email;
 }
+
+

--- a/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeSendResponse.java
+++ b/src/main/java/me/minkh/app/dto/account/verificationcode/VerificationCodeSendResponse.java
@@ -1,0 +1,26 @@
+package me.minkh.app.dto.account.verificationcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import me.minkh.app.domain.account.VerificationCode;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class VerificationCodeSendResponse {
+
+    private final String code;
+
+    private final String email;
+
+    private final LocalDateTime expiredDate;
+
+    public VerificationCodeSendResponse(VerificationCode verificationCode) {
+        this.code = verificationCode.getCode();
+        this.email = verificationCode.getAccount().getEmail();
+        this.expiredDate = verificationCode.getExpiredDate();
+    }
+}
+
+

--- a/src/main/java/me/minkh/app/exception/advice/ControllerAdvice.java
+++ b/src/main/java/me/minkh/app/exception/advice/ControllerAdvice.java
@@ -44,6 +44,9 @@ public class ControllerAdvice {
         log.error("httpClientErrorException", e);
         HttpStatus httpStatus = (HttpStatus) e.getStatusCode();
         // TODO: 이후에 message 처리 방법을 고려해 봐야 한다.
+        if (httpStatus == HttpStatus.UNAUTHORIZED) {
+            return this.exceptionHandler(e, httpStatus, "유효하지 않은 API키 입니다.");
+        }
         return this.exceptionHandler(e, httpStatus, e.getMessage());
     }
 

--- a/src/main/java/me/minkh/app/service/MailService.java
+++ b/src/main/java/me/minkh/app/service/MailService.java
@@ -1,0 +1,35 @@
+package me.minkh.app.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private static final String subject = "인증번호";
+
+    @Async
+    public void sendEmail(String to, String content) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message);
+
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(content);
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            log.error("메일 전송 실패 : {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/me/minkh/app/service/MailService.java
+++ b/src/main/java/me/minkh/app/service/MailService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 public class MailService {
 
     private final JavaMailSender mailSender;
-    private static final String subject = "인증번호";
+    private static final String SUBJECT = "인증번호";
 
     @Async
     public void sendEmail(String to, String content) {
@@ -24,7 +24,7 @@ public class MailService {
             MimeMessageHelper helper = new MimeMessageHelper(message);
 
             helper.setTo(to);
-            helper.setSubject(subject);
+            helper.setSubject(SUBJECT);
             helper.setText(content);
 
             mailSender.send(message);

--- a/src/main/java/me/minkh/app/service/account/AccountService.java
+++ b/src/main/java/me/minkh/app/service/account/AccountService.java
@@ -21,6 +21,8 @@ public class AccountService implements UserDetailsService {
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
 
+    private static final String INVALID_REQUEST_MESSAGE = "은 올바르지 않은 요청입니다.";
+
     public AccountResponse save(AccountRequest accountRequest) {
         accountRequest.encodePassword(this.passwordEncoder);
         Account savedAccount = accountRepository.save(accountRequest.toEntity());
@@ -29,21 +31,21 @@ public class AccountService implements UserDetailsService {
 
     public AccountResponse findById(Long id) {
         Account account = this.accountRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException(id + "은 올바르지 않은 요청입니다."));
+                .orElseThrow(() -> new IllegalArgumentException(id + INVALID_REQUEST_MESSAGE));
         return new AccountResponse(account);
     }
 
     public AccountResponse updateApiKey(UpdateApiKeyRequest request, Long id) {
         String apiKey = request.getApiKey();
         Account account = this.accountRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException(id + "은 올바르지 않은 요청입니다."));
+                .orElseThrow(() -> new IllegalArgumentException(id + INVALID_REQUEST_MESSAGE));
         return new AccountResponse(account.updateApiKey(apiKey));
     }
 
     @Override
     public AccountAdapter loadUserByUsername(String username) throws UsernameNotFoundException {
         Account account = accountRepository.findByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException(username + "은 올바르지 않은 요청입니다."));
+                .orElseThrow(() -> new UsernameNotFoundException(username + INVALID_REQUEST_MESSAGE));
         return new AccountAdapter(account);
     }
 }

--- a/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
+++ b/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -69,7 +69,6 @@ public class VerificationCodeService {
     }
 
     private String getCode() {
-        int num = 100_000 + ThreadLocalRandom.current().nextInt(900_000);
-        return String.valueOf(num);
+        return UUID.randomUUID().toString().substring(0, 8);
     }
 }

--- a/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
+++ b/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
@@ -1,0 +1,75 @@
+package me.minkh.app.service.account;
+
+import lombok.RequiredArgsConstructor;
+import me.minkh.app.domain.account.Account;
+import me.minkh.app.domain.account.AccountRepository;
+import me.minkh.app.domain.account.VerificationCode;
+import me.minkh.app.domain.account.VerificationCodeRepository;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckResponse;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendResponse;
+import me.minkh.app.service.MailService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class VerificationCodeService {
+
+    private final MailService mailService;
+    private final AccountRepository accountRepository;
+    private final VerificationCodeRepository verificationCodeRepository;
+
+    @Transactional
+    public VerificationCodeSendResponse send(VerificationCodeSendRequest request) {
+        String email = request.getEmail();
+        Account account = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException(email + "은 올바르지 않은 요청입니다."));
+
+        // 인증번호를 생성하고, 이메일을 전송한다.
+        String code = getCode();
+        this.mailService.sendEmail(email, code);
+
+        // 인증번호 전용 테이블에 인증번호를 넣는다. 유효 시간은 3분이다.
+        LocalDateTime expiredDate = LocalDateTime.now().plusMinutes(3);
+
+        // 인증번호가 있으면? 갱신한 것이다. 인증번호가 없으면? 새로 등록하는 것이다.
+        VerificationCode verificationCode = verificationCodeRepository.findByAccount(account)
+                .orElse(new VerificationCode());
+
+        verificationCode.update(code, account, expiredDate);
+        return new VerificationCodeSendResponse(verificationCodeRepository.save(verificationCode));
+    }
+
+    @Transactional
+    public VerificationCodeCheckResponse check(VerificationCodeCheckRequest request) {
+        String email = request.getEmail();
+        Account account = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException(email + "은 올바르지 않은 요청입니다."));
+
+        VerificationCode verificationCode = verificationCodeRepository.findByAccount(account)
+                .orElseThrow(() -> new IllegalArgumentException("인증번호를 재발급 받으세요."));
+
+        // 코드가 일치하지 않을 때,
+        if (verificationCode.isCodeMisMatch(request.getCode())) {
+            throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+        }
+
+        // 유효기간이 만료됐을 때,
+        if (verificationCode.isExpired()) {
+            throw new IllegalArgumentException("유효기간이 만료된 인증번호 입니다.");
+        }
+
+        account.verifiedEmail();
+        return new VerificationCodeCheckResponse(true);
+    }
+
+    private String getCode() {
+        int num = 100_000 + new Random().nextInt(900_000);
+        return String.valueOf(num);
+    }
+}

--- a/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
+++ b/src/main/java/me/minkh/app/service/account/VerificationCodeService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 @RequiredArgsConstructor
 @Service
@@ -69,7 +69,7 @@ public class VerificationCodeService {
     }
 
     private String getCode() {
-        int num = 100_000 + new Random().nextInt(900_000);
+        int num = 100_000 + ThreadLocalRandom.current().nextInt(900_000);
         return String.valueOf(num);
     }
 }

--- a/src/test/java/me/minkh/app/service/account/AccountServiceTest.java
+++ b/src/test/java/me/minkh/app/service/account/AccountServiceTest.java
@@ -2,6 +2,7 @@ package me.minkh.app.service.account;
 
 import me.minkh.app.domain.account.Account;
 import me.minkh.app.domain.account.AccountRepository;
+import me.minkh.app.dto.account.AccountRequest;
 import me.minkh.app.dto.account.AccountResponse;
 import me.minkh.app.dto.account.UpdateApiKeyRequest;
 import org.junit.jupiter.api.AfterEach;
@@ -29,6 +30,25 @@ class AccountServiceTest {
     @AfterEach
     void afterEach() {
         this.accountRepository.deleteAll();
+    }
+
+    @DisplayName("Account 저장 테스트")
+    @Test
+    void save() {
+        // given
+        AccountRequest accountRequest = AccountRequest.builder()
+                .email("test@test.com")
+                .name("test")
+                .password("password")
+                .build();
+
+        // when
+        AccountResponse accountResponse = accountService.save(accountRequest);
+
+        // then
+        assertThat(accountResponse.getEmail()).isEqualTo(accountRequest.getEmail());
+        assertThat(accountResponse.getName()).isEqualTo(accountRequest.getName());
+        assertThat(accountResponse.getApiKey()).isNull();
     }
 
     @DisplayName("API Key 업데이트 성공 테스트")

--- a/src/test/java/me/minkh/app/service/account/VerificationCodeServiceTest.java
+++ b/src/test/java/me/minkh/app/service/account/VerificationCodeServiceTest.java
@@ -1,0 +1,182 @@
+package me.minkh.app.service.account;
+
+import me.minkh.app.domain.account.Account;
+import me.minkh.app.domain.account.AccountRepository;
+import me.minkh.app.domain.account.VerificationCode;
+import me.minkh.app.domain.account.VerificationCodeRepository;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeCheckResponse;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendRequest;
+import me.minkh.app.dto.account.verificationcode.VerificationCodeSendResponse;
+import me.minkh.app.service.MailService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class VerificationCodeServiceTest {
+
+    @Autowired
+    VerificationCodeService verificationCodeService;
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    VerificationCodeRepository verificationCodeRepository;
+
+    @AfterEach
+    void afterEach() {
+        verificationCodeRepository.deleteAll();
+        accountRepository.deleteAll();
+    }
+
+    @MockBean
+    MailService mailService;
+
+    @DisplayName("Send 성공 테스트")
+    @Test
+    void send() {
+        // given
+        Account account = saveAccount();
+        VerificationCodeSendRequest request = VerificationCodeSendRequest.builder()
+                .email(account.getEmail())
+                .build();
+
+        // when
+        VerificationCodeSendResponse response = this.verificationCodeService.send(request);
+        doNothing().when(mailService).sendEmail(anyString(), anyString());
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(request.getEmail());
+        assertThat(response.getCode().length()).isEqualTo(6);
+        assertThat(response.getExpiredDate()).isAfter(LocalDateTime.now());
+    }
+
+    @DisplayName("Send 실패 테스트")
+    @Test
+    void sendFail() {
+        // given
+        VerificationCodeSendRequest request = VerificationCodeSendRequest.builder()
+                .email("fail@tset.com")
+                .build();
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> this.verificationCodeService.send(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Check 성공 테스트")
+    @Test
+    void check() {
+        // given
+        Account account = saveAccount();
+        VerificationCode verificationCode = saveVerificationCode(account, LocalDateTime.now().plusMinutes(3));
+        VerificationCodeCheckRequest request = VerificationCodeCheckRequest.builder()
+                .email(account.getEmail())
+                .code(verificationCode.getCode())
+                .build();
+
+        // when
+        VerificationCodeCheckResponse response = verificationCodeService.check(request);
+        Account findAccount = accountRepository.findByEmail(account.getEmail()).orElseThrow();
+
+        // then
+        assertThat(findAccount.isEmailVerified()).isTrue();
+        assertThat(response.isSuccess()).isTrue();
+    }
+
+    @DisplayName("Check 실패 테스트1 - Account 없음")
+    @Test
+    void checkFail1() {
+        // given
+        VerificationCodeCheckRequest request = VerificationCodeCheckRequest.builder()
+                .email("test@test.com")
+                .code("1234567")
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.check(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Check 실패 테스트2 - VerificationCode 없음")
+    @Test
+    void checkFail2() {
+        // given
+        Account account = saveAccount();
+        VerificationCodeCheckRequest request = VerificationCodeCheckRequest.builder()
+                .email(account.getEmail())
+                .code("123456")
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.check(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Check 실패 테스트3 - 코드가 일치하지 않음")
+    @Test
+    void checkFail3() {
+        // given
+        Account account = saveAccount();
+        VerificationCode verificationCode = saveVerificationCode(account, LocalDateTime.now().plusMinutes(3));
+        VerificationCodeCheckRequest request = VerificationCodeCheckRequest.builder()
+                .email(account.getEmail())
+                .code(verificationCode.getCode() + "0")
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.check(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Check 실패 테스트4 - 유효기간 만료")
+    @Test
+    void checkFail4() {
+        // given
+        Account account = saveAccount();
+        VerificationCode verificationCode = saveVerificationCode(account, LocalDateTime.now());
+        VerificationCodeCheckRequest request = VerificationCodeCheckRequest.builder()
+                .email(account.getEmail())
+                .code(verificationCode.getCode())
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.check(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private Account saveAccount() {
+        return accountRepository.save(
+                Account.builder()
+                        .email("test@test.com")
+                        .name("test")
+                        .password("password")
+                        .build()
+        );
+    }
+
+    private VerificationCode saveVerificationCode(Account account, LocalDateTime expiredDate) {
+        return verificationCodeRepository.save(
+                VerificationCode.builder()
+                        .code("123456")
+                        .expiredDate(expiredDate)
+                        .account(account)
+                        .build()
+        );
+    }
+}

--- a/src/test/java/me/minkh/app/service/account/VerificationCodeServiceTest.java
+++ b/src/test/java/me/minkh/app/service/account/VerificationCodeServiceTest.java
@@ -62,7 +62,7 @@ class VerificationCodeServiceTest {
 
         // then
         assertThat(response.getEmail()).isEqualTo(request.getEmail());
-        assertThat(response.getCode().length()).isEqualTo(6);
+        assertThat(response.getCode().length()).isEqualTo(8);
         assertThat(response.getExpiredDate()).isAfter(LocalDateTime.now());
     }
 
@@ -173,7 +173,7 @@ class VerificationCodeServiceTest {
     private VerificationCode saveVerificationCode(Account account, LocalDateTime expiredDate) {
         return verificationCodeRepository.save(
                 VerificationCode.builder()
-                        .code("123456")
+                        .code("12345678")
                         .expiredDate(expiredDate)
                         .account(account)
                         .build()


### PR DESCRIPTION
해당 PR에서는 아래의 작업을 진행하였습니다.

## Basic Authentication

- Authorization 헤더에 base64로 인코딩 된 username:password 문자열로 전송하면 인증할 수 있도록 추가하였습니다.
- OAuth 2.0 클라이언트를 이용하는 것이 아닌 스프링 시큐리티를 학습해 보고자 진행하였습니다.
- Basic Authentication를 추가함에 따라 인증 문제로 포스트맨 테스트가 불가능 했던 부분을 해결하였습니다.

## AuthenticationPrincipal 

- SecurityContextHolder 에서 인증된 사용자 객체인 UserDetails를 꺼내오기 위해 UserDetailsService 인터페이스를 구현해야 했습니다.
- 이에, OAuth 2.0 클라이언트로 인증된 유저와 Basic Authentication로 인증된 유저 전부 인증된 사용자 객체로 만들고 싶었고, 어댑터 패턴을 이용하여 구현하였습니다.
- 기존에 HttpSession에서 식별자를 불러오던 부분을 SecurityContextHolder의 인증 객체에서 꺼내온 뒤 사용하도록 리팩터링 하였습니다.

## 회원가입 기능 추가

- email, name, password 를 필수값으로 받는 회원가입 기능을 추가하였습니다.
- password는 인코딩 하여 저장되도록 구현하였습니다.
- 기능 추가에 따른 테스트 코드를 작성하였습니다.

## 이메일 인증 기능 추가

- 회원가입된 유저가 이메일 인증을 할 수 있는 기능을 추가하였습니다.
- Account와 1:1 관계의 인증 번호 테이블을 만들어 관리하고 있습니다.
- 메일을 전송할 때는 대기 시간이 생각보다 오래 걸려 비동기로 작동할 수 있게 `@Async`, `@EnableAsync` 어노테이션을 추가하였습니다.
- 기능 추가에 따른 테스트 코드를 작성하였습니다.