### PR TITLE
세션 저장소(데이터베이스) 생성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           script: |
             cd /home/ec2-user
-            docker-compose pull app
-            docker-compose up -d app
+            docker-compose pull
+            docker-compose up -d
             docker image prune -a -f
 
       # GitHub Actions VM 환경의 IP를 인바운드 규칙에서 제거한다.

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.session:spring-session-jdbc'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
+++ b/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class AccountAdapter implements OAuth2User, UserDetails {
 
     private final Account account;
-    private Map<String, Object> attributes;
+    private transient Map<String, Object> attributes;
 
     public AccountAdapter(Account account) {
         this.account = account;

--- a/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
+++ b/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class AccountAdapter implements OAuth2User, UserDetails {
 
     private final Account account;
-    private OAuth2User oAuth2User;
+    private Map<String, Object> attributes;
 
     public AccountAdapter(Account account) {
         this.account = account;
@@ -22,14 +22,14 @@ public class AccountAdapter implements OAuth2User, UserDetails {
 
     public AccountAdapter(Account account, OAuth2User oAuth2User) {
         this.account = account;
-        this.oAuth2User = oAuth2User;
+        this.attributes = oAuth2User.getAttributes();
     }
 
     // OAuth2User
 
     @Override
     public Map<String, Object> getAttributes() {
-        return this.oAuth2User.getAttributes();
+        return this.attributes;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class AccountAdapter implements OAuth2User, UserDetails {
 
     @Override
     public String getName() {
-        return this.oAuth2User.getAttribute("name");
+        return this.getAttribute("name");
     }
 
     // UserDetails

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor
@@ -33,9 +32,6 @@ public class SecurityConfig {
 
         // Basic Authentication 활성화
         http.httpBasic(h -> h.realmName("App"));
-
-        // 세션 활성화
-        http.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         // OAuth2
         http.oauth2Login(o -> o.loginPage("/login").userInfoEndpoint(u -> u.userService(oAuth2UserService)));

--- a/src/main/java/me/minkh/app/domain/model/BaseEntity.java
+++ b/src/main/java/me/minkh/app/domain/model/BaseEntity.java
@@ -6,9 +6,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
+import java.io.Serializable;
+
 @Getter
 @MappedSuperclass
-public class BaseEntity {
+public class BaseEntity implements Serializable {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
로드밸런서(Nginx) 설치 이후 2개의 서버를 띄워 라우팅 테스트를 해보았습니다.

이에 인증 객체를 공유하지 못하는 문제를 파악하였습니다.

따라서, 공유할 수 있는 세션 저장소를 생성하기로 하였습니다.

- 스프링 세션 의존성 추가
- 직렬화를 위한 BaseEntity 수정

을 진행하였습니다.