### PR TITLE
프리셋 기능 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           script: |
             cd /home/ec2-user
-            docker-compose pull app
-            docker-compose up -d app
+            docker-compose pull
+            docker-compose up -d
             docker image prune -a -f
 
       # GitHub Actions VM 환경의 IP를 인바운드 규칙에서 제거한다.

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.session:spring-session-jdbc'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
+++ b/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class AccountAdapter implements OAuth2User, UserDetails {
 
     private final Account account;
-    private Map<String, Object> attributes;
+    private transient Map<String, Object> attributes;
 
     public AccountAdapter(Account account) {
         this.account = account;

--- a/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
+++ b/src/main/java/me/minkh/app/config/auth/AccountAdapter.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class AccountAdapter implements OAuth2User, UserDetails {
 
     private final Account account;
-    private OAuth2User oAuth2User;
+    private Map<String, Object> attributes;
 
     public AccountAdapter(Account account) {
         this.account = account;
@@ -22,14 +22,14 @@ public class AccountAdapter implements OAuth2User, UserDetails {
 
     public AccountAdapter(Account account, OAuth2User oAuth2User) {
         this.account = account;
-        this.oAuth2User = oAuth2User;
+        this.attributes = oAuth2User.getAttributes();
     }
 
     // OAuth2User
 
     @Override
     public Map<String, Object> getAttributes() {
-        return this.oAuth2User.getAttributes();
+        return this.attributes;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class AccountAdapter implements OAuth2User, UserDetails {
 
     @Override
     public String getName() {
-        return this.oAuth2User.getAttribute("name");
+        return this.getAttribute("name");
     }
 
     // UserDetails

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor
@@ -33,9 +32,6 @@ public class SecurityConfig {
 
         // Basic Authentication 활성화
         http.httpBasic(h -> h.realmName("App"));
-
-        // 세션 활성화
-        http.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         // OAuth2
         http.oauth2Login(o -> o.loginPage("/login").userInfoEndpoint(u -> u.userService(oAuth2UserService)));

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig {
 
     private final MyOAuth2UserService oAuth2UserService;
 
-    private static final String[] AUTH_LIST = { "/info/**" };
+    private static final String[] AUTH_LIST = { "/info/**", "/engravings/presets" };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
+++ b/src/main/java/me/minkh/app/config/auth/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig {
 
     private final MyOAuth2UserService oAuth2UserService;
 
-    private static final String[] AUTH_LIST = { "/info/**", "/engravings/presets" };
+    private static final String[] AUTH_LIST = { "/info/**", "/engravings/presets/**" };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -6,10 +6,7 @@ import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
 import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
 import me.minkh.app.dto.engraving.response.EngravingPresetResponse;
 import me.minkh.app.service.engraving.EngravingService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -31,5 +28,15 @@ public class EngravingController {
             @CurrentId Long accountId
     ) {
         return this.engravingService.savePreset(request, accountId);
+    }
+
+    @GetMapping("/presets")
+    public List<EngravingPresetResponse> getPresets(@CurrentId Long accountId) {
+        return this.engravingService.getPresets(accountId);
+    }
+
+    @GetMapping("/presets/{presetId}")
+    public EngravingPresetResponse getPreset(@PathVariable("presetId") Long presetId, @CurrentId Long accountId) {
+        return this.engravingService.getPreset(presetId, accountId);
     }
 }

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -3,8 +3,12 @@ package me.minkh.app.controller;
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
 import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
+import me.minkh.app.dto.engraving.response.EngravingPresetResponse;
 import me.minkh.app.service.engraving.EngravingService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -16,7 +20,12 @@ public class EngravingController {
     private final EngravingService engravingService;
 
     @PostMapping("/calc")
-    public List<EngravingCalcResponse> calcEngravings(@RequestBody EngravingSetupRequest requestDto) {
-        return this.engravingService.calcEngravings(requestDto);
+    public List<EngravingCalcResponse> calcEngravings(@RequestBody EngravingSetupRequest request) {
+        return this.engravingService.calcEngravings(request);
+    }
+
+    @PostMapping("/presets")
+    public EngravingPresetResponse savePreset(@RequestBody EngravingSetupRequest request) {
+        return this.engravingService.savePreset(request);
     }
 }

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -10,11 +10,12 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/engravings")
 public class EngravingController {
 
     private final EngravingService engravingService;
 
-    @PostMapping("/calc/engravings")
+    @PostMapping("/calc")
     public List<CalcEngravingResponse> calcEngravings(@RequestBody CalcEngravingRequest requestDto) {
         return this.engravingService.calcEngravings(requestDto);
     }

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -1,8 +1,8 @@
 package me.minkh.app.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.minkh.app.dto.engraving.request.CalcEngravingRequest;
-import me.minkh.app.dto.engraving.response.CalcEngravingResponse;
+import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
+import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
 import me.minkh.app.service.engraving.EngravingService;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +16,7 @@ public class EngravingController {
     private final EngravingService engravingService;
 
     @PostMapping("/calc")
-    public List<CalcEngravingResponse> calcEngravings(@RequestBody CalcEngravingRequest requestDto) {
+    public List<EngravingCalcResponse> calcEngravings(@RequestBody EngravingSetupRequest requestDto) {
         return this.engravingService.calcEngravings(requestDto);
     }
 }

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -1,6 +1,7 @@
 package me.minkh.app.controller;
 
 import lombok.RequiredArgsConstructor;
+import me.minkh.app.config.auth.CurrentId;
 import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
 import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
 import me.minkh.app.dto.engraving.response.EngravingPresetResponse;
@@ -25,7 +26,10 @@ public class EngravingController {
     }
 
     @PostMapping("/presets")
-    public EngravingPresetResponse savePreset(@RequestBody EngravingSetupRequest request) {
-        return this.engravingService.savePreset(request);
+    public EngravingPresetResponse savePreset(
+            @RequestBody EngravingSetupRequest request,
+            @CurrentId Long accountId
+    ) {
+        return this.engravingService.savePreset(request, accountId);
     }
 }

--- a/src/main/java/me/minkh/app/controller/EngravingController.java
+++ b/src/main/java/me/minkh/app/controller/EngravingController.java
@@ -39,4 +39,9 @@ public class EngravingController {
     public EngravingPresetResponse getPreset(@PathVariable("presetId") Long presetId, @CurrentId Long accountId) {
         return this.engravingService.getPreset(presetId, accountId);
     }
+
+    @DeleteMapping("/presets/{presetId}")
+    public EngravingPresetResponse deletePreset(@PathVariable("presetId") Long presetId, @CurrentId Long accountId) {
+        return this.engravingService.deletePreset(presetId, accountId);
+    }
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/CombatStat.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/CombatStat.java
@@ -1,0 +1,15 @@
+package me.minkh.app.domain.engraving.preset;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import me.minkh.app.domain.model.BaseEntity;
+
+@Getter
+@Entity
+public class CombatStat extends BaseEntity {
+
+    private String type;
+
+    private int value;
+}
+

--- a/src/main/java/me/minkh/app/domain/engraving/preset/CombatStat.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/CombatStat.java
@@ -1,9 +1,17 @@
 package me.minkh.app.domain.engraving.preset;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.minkh.app.domain.model.BaseEntity;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 @Entity
 public class CombatStat extends BaseEntity {
@@ -11,5 +19,13 @@ public class CombatStat extends BaseEntity {
     private String type;
 
     private int value;
+
+    @ManyToOne
+    @JoinColumn(name = "preset_id")
+    private Preset preset;
+
+    public void addPreset(Preset preset) {
+        this.preset = preset;
+    }
 }
 

--- a/src/main/java/me/minkh/app/domain/engraving/preset/CombatStatRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/CombatStatRepository.java
@@ -1,7 +1,0 @@
-package me.minkh.app.domain.engraving.preset;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CombatStatRepository extends JpaRepository<CombatStat, Long> {
-
-}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/CombatStatRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/CombatStatRepository.java
@@ -1,0 +1,7 @@
+package me.minkh.app.domain.engraving.preset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CombatStatRepository extends JpaRepository<CombatStat, Long> {
+
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Elixir.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Elixir.java
@@ -2,11 +2,14 @@ package me.minkh.app.domain.engraving.preset;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 public class Elixir {
 

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Elixir.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Elixir.java
@@ -1,0 +1,18 @@
+package me.minkh.app.domain.engraving.preset;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+public class Elixir {
+
+    private String type;
+
+    private int level;
+
+    private int headOffensePower;
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Engraving.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Engraving.java
@@ -1,9 +1,17 @@
 package me.minkh.app.domain.engraving.preset;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.minkh.app.domain.model.BaseEntity;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 @Entity
 public class Engraving extends BaseEntity {
@@ -11,4 +19,12 @@ public class Engraving extends BaseEntity {
     private String name;
 
     private int level;
+
+    @ManyToOne
+    @JoinColumn(name = "preset_id")
+    private Preset preset;
+
+    public void addPreset(Preset preset) {
+        this.preset = preset;
+    }
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Engraving.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Engraving.java
@@ -1,0 +1,14 @@
+package me.minkh.app.domain.engraving.preset;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import me.minkh.app.domain.model.BaseEntity;
+
+@Getter
+@Entity
+public class Engraving extends BaseEntity {
+
+    private String name;
+
+    private int level;
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/EngravingRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/EngravingRepository.java
@@ -1,0 +1,7 @@
+package me.minkh.app.domain.engraving.preset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EngravingRepository extends JpaRepository<Engraving, Long> {
+
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/EngravingRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/EngravingRepository.java
@@ -1,7 +1,0 @@
-package me.minkh.app.domain.engraving.preset;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface EngravingRepository extends JpaRepository<Engraving, Long> {
-
-}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Etc.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Etc.java
@@ -1,0 +1,20 @@
+package me.minkh.app.domain.engraving.preset;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+public class Etc {
+
+    private double criticalDamage;
+
+    private double criticalHitRate;
+
+    private double attackIncrease;
+
+    private double speedIncrease;
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Etc.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Etc.java
@@ -2,11 +2,14 @@ package me.minkh.app.domain.engraving.preset;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 public class Etc {
 

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
@@ -1,16 +1,18 @@
 package me.minkh.app.domain.engraving.preset;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.minkh.app.domain.model.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 @Entity
 public class Preset extends BaseEntity {
@@ -20,14 +22,26 @@ public class Preset extends BaseEntity {
     @Embedded
     private Elixir elixir;
 
-    @OneToMany
-    @JoinColumn(name = "preset_id")
+    @OneToMany(mappedBy = "preset", cascade = CascadeType.ALL)
     private List<CombatStat> combatStats = new ArrayList<>();
 
-    @OneToMany
-    @JoinColumn(name = "preset_id")
+    @OneToMany(mappedBy = "preset", cascade = CascadeType.ALL)
     private List<Engraving> engravings = new ArrayList<>();
 
     @Embedded
     private Etc etc;
+
+    public Preset(String artifact, Elixir elixir, Etc etc, List<CombatStat> combatStats, List<Engraving> engravings) {
+        this.artifact = artifact;
+        this.elixir = elixir;
+        this.etc = etc;
+        for (CombatStat combatStat : combatStats) {
+            combatStat.addPreset(this);
+        }
+        this.combatStats = combatStats;
+        for (Engraving engraving : engravings) {
+            engraving.addPreset(this);
+        }
+        this.engravings = engravings;
+    }
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
@@ -1,12 +1,10 @@
 package me.minkh.app.domain.engraving.preset;
 
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import me.minkh.app.domain.account.Account;
 import me.minkh.app.domain.model.BaseEntity;
 
 import java.util.ArrayList;
@@ -31,6 +29,10 @@ public class Preset extends BaseEntity {
     @Embedded
     private Etc etc;
 
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
+
     public Preset(String artifact, Elixir elixir, Etc etc, List<CombatStat> combatStats, List<Engraving> engravings) {
         this.artifact = artifact;
         this.elixir = elixir;
@@ -43,5 +45,9 @@ public class Preset extends BaseEntity {
             engraving.addPreset(this);
         }
         this.engravings = engravings;
+    }
+
+    public void addAccount(Account account) {
+        this.account = account;
     }
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/Preset.java
@@ -1,0 +1,33 @@
+package me.minkh.app.domain.engraving.preset;
+
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import me.minkh.app.domain.model.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+public class Preset extends BaseEntity {
+
+    private String artifact;
+
+    @Embedded
+    private Elixir elixir;
+
+    @OneToMany
+    @JoinColumn(name = "preset_id")
+    private List<CombatStat> combatStats = new ArrayList<>();
+
+    @OneToMany
+    @JoinColumn(name = "preset_id")
+    private List<Engraving> engravings = new ArrayList<>();
+
+    @Embedded
+    private Etc etc;
+}

--- a/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
@@ -4,8 +4,11 @@ import me.minkh.app.domain.account.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PresetRepository extends JpaRepository<Preset, Long> {
 
     List<Preset> findByAccount(Account account);
+
+    Optional<Preset> findByIdAndAccount(Long presetId, Account account);
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
@@ -1,7 +1,11 @@
 package me.minkh.app.domain.engraving.preset;
 
+import me.minkh.app.domain.account.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface PresetRepository extends JpaRepository<Preset, Long> {
 
+    List<Preset> findByAccount(Account account);
 }

--- a/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
+++ b/src/main/java/me/minkh/app/domain/engraving/preset/PresetRepository.java
@@ -1,0 +1,7 @@
+package me.minkh.app.domain.engraving.preset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PresetRepository extends JpaRepository<Preset, Long> {
+
+}

--- a/src/main/java/me/minkh/app/domain/model/BaseEntity.java
+++ b/src/main/java/me/minkh/app/domain/model/BaseEntity.java
@@ -6,9 +6,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
+import java.io.Serializable;
+
 @Getter
 @MappedSuperclass
-public class BaseEntity {
+public class BaseEntity implements Serializable {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/me/minkh/app/dto/engraving/request/CombatStatDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/CombatStatDto.java
@@ -7,9 +7,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class Engraving {
+public class CombatStatDto {
 
-    private String name;
+    private String type;
 
-    private int level;
+    private int value;
 }
+

--- a/src/main/java/me/minkh/app/dto/engraving/request/CombatStatDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/CombatStatDto.java
@@ -3,6 +3,7 @@ package me.minkh.app.dto.engraving.request;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import me.minkh.app.domain.engraving.preset.CombatStat;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,5 +13,12 @@ public class CombatStatDto {
     private String type;
 
     private int value;
+
+    public CombatStat toEntity() {
+        return CombatStat.builder()
+                .type(this.type)
+                .value(this.value)
+                .build();
+    }
 }
 

--- a/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
@@ -7,10 +7,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class CombatStat {
+public class ElixirDto {
 
     private String type;
 
-    private int value;
-}
+    private int level;
 
+    private int headOffensePower;
+}

--- a/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
@@ -20,6 +20,7 @@ public class ElixirDto {
         return Elixir.builder()
                 .type(this.type)
                 .level(this.level)
+                .headOffensePower(this.headOffensePower)
                 .build();
     }
 }

--- a/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/ElixirDto.java
@@ -3,6 +3,7 @@ package me.minkh.app.dto.engraving.request;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import me.minkh.app.domain.engraving.preset.Elixir;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,4 +15,11 @@ public class ElixirDto {
     private int level;
 
     private int headOffensePower;
+
+    public Elixir toEntity() {
+        return Elixir.builder()
+                .type(this.type)
+                .level(this.level)
+                .build();
+    }
 }

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingDto.java
@@ -7,11 +7,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class Elixir {
+public class EngravingDto {
 
-    private String type;
+    private String name;
 
     private int level;
-
-    private int headOffensePower;
 }

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingDto.java
@@ -3,6 +3,7 @@ package me.minkh.app.dto.engraving.request;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import me.minkh.app.domain.engraving.preset.Engraving;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,4 +13,11 @@ public class EngravingDto {
     private String name;
 
     private int level;
+
+    public Engraving toEntity() {
+        return Engraving.builder()
+                .name(this.name)
+                .level(this.level)
+                .build();
+    }
 }

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class CalcEngravingRequest {
+public class EngravingSetupRequest {
 
     private String artifact;
 

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
@@ -1,5 +1,7 @@
 package me.minkh.app.dto.engraving.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import me.minkh.app.domain.engraving.preset.CombatStat;
 import me.minkh.app.domain.engraving.preset.Engraving;
@@ -7,6 +9,8 @@ import me.minkh.app.domain.engraving.preset.Preset;
 
 import java.util.List;
 
+@AllArgsConstructor
+@Builder
 @Data
 public class EngravingSetupRequest {
 

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
@@ -1,6 +1,9 @@
 package me.minkh.app.dto.engraving.request;
 
 import lombok.Data;
+import me.minkh.app.domain.engraving.preset.CombatStat;
+import me.minkh.app.domain.engraving.preset.Engraving;
+import me.minkh.app.domain.engraving.preset.Preset;
 
 import java.util.List;
 
@@ -16,5 +19,25 @@ public class EngravingSetupRequest {
     private List<EngravingDto> engravings;
 
     private EtcDto etc;
+
+    public Preset toEntity() {
+        List<CombatStat> combatStats = this.getCombatStats()
+                .stream()
+                .map(CombatStatDto::toEntity)
+                .toList();
+
+        List<Engraving> engravings = this.getEngravings()
+                .stream()
+                .map(EngravingDto::toEntity)
+                .toList();
+
+        return new Preset(
+                this.artifact,
+                this.elixir.toEntity(),
+                this.etc.toEntity(),
+                combatStats,
+                engravings
+        );
+    }
 }
 

--- a/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EngravingSetupRequest.java
@@ -9,12 +9,12 @@ public class EngravingSetupRequest {
 
     private String artifact;
 
-    private Elixir elixir;
+    private ElixirDto elixir;
 
-    private List<CombatStat> combatStats;
+    private List<CombatStatDto> combatStats;
 
-    private List<Engraving> engravings;
+    private List<EngravingDto> engravings;
 
-    private Etc etc;
+    private EtcDto etc;
 }
 

--- a/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
@@ -3,7 +3,6 @@ package me.minkh.app.dto.engraving.request;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import me.minkh.app.domain.engraving.preset.Elixir;
 import me.minkh.app.domain.engraving.preset.Etc;
 
 @AllArgsConstructor

--- a/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
@@ -3,6 +3,8 @@ package me.minkh.app.dto.engraving.request;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import me.minkh.app.domain.engraving.preset.Elixir;
+import me.minkh.app.domain.engraving.preset.Etc;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -16,4 +18,13 @@ public class EtcDto {
     private double attackIncrease;
 
     private double speedIncrease;
+
+    public Etc toEntity() {
+        return Etc.builder()
+                .criticalDamage(this.criticalDamage)
+                .criticalHitRate(this.criticalHitRate)
+                .attackIncrease(this.attackIncrease)
+                .speedIncrease(this.speedIncrease)
+                .build();
+    }
 }

--- a/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
+++ b/src/main/java/me/minkh/app/dto/engraving/request/EtcDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class Etc {
+public class EtcDto {
 
     private double criticalDamage;
 

--- a/src/main/java/me/minkh/app/dto/engraving/response/EngravingCalcResponse.java
+++ b/src/main/java/me/minkh/app/dto/engraving/response/EngravingCalcResponse.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @AllArgsConstructor
 @Data
-public class CalcEngravingResponse {
+public class EngravingCalcResponse {
 
     private String name;
 

--- a/src/main/java/me/minkh/app/dto/engraving/response/EngravingPresetResponse.java
+++ b/src/main/java/me/minkh/app/dto/engraving/response/EngravingPresetResponse.java
@@ -14,6 +14,8 @@ import java.util.List;
 @Data
 public class EngravingPresetResponse {
 
+    private Long id;
+
     private String artifact;
 
     private ElixirDto elixir;
@@ -25,6 +27,7 @@ public class EngravingPresetResponse {
     private EtcDto etc;
 
     public EngravingPresetResponse(Preset preset) {
+        this.id = preset.getId();
         this.artifact = preset.getArtifact();
         this.elixir = new ElixirDto(
                 preset.getElixir().getType(),

--- a/src/main/java/me/minkh/app/dto/engraving/response/EngravingPresetResponse.java
+++ b/src/main/java/me/minkh/app/dto/engraving/response/EngravingPresetResponse.java
@@ -1,0 +1,47 @@
+package me.minkh.app.dto.engraving.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import me.minkh.app.domain.engraving.preset.Preset;
+import me.minkh.app.dto.engraving.request.CombatStatDto;
+import me.minkh.app.dto.engraving.request.ElixirDto;
+import me.minkh.app.dto.engraving.request.EngravingDto;
+import me.minkh.app.dto.engraving.request.EtcDto;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Data
+public class EngravingPresetResponse {
+
+    private String artifact;
+
+    private ElixirDto elixir;
+
+    private List<CombatStatDto> combatStats;
+
+    private List<EngravingDto> engravings;
+
+    private EtcDto etc;
+
+    public EngravingPresetResponse(Preset preset) {
+        this.artifact = preset.getArtifact();
+        this.elixir = new ElixirDto(
+                preset.getElixir().getType(),
+                preset.getElixir().getLevel(),
+                preset.getElixir().getHeadOffensePower()
+        );
+        this.combatStats = preset.getCombatStats().stream()
+                .map(combatStat -> new CombatStatDto(combatStat.getType(), combatStat.getValue()))
+                .toList();
+        this.engravings = preset.getEngravings().stream()
+                .map(engraving -> new EngravingDto(engraving.getName(), engraving.getLevel()))
+                .toList();
+        this.etc = new EtcDto(
+                preset.getEtc().getCriticalDamage(),
+                preset.getEtc().getCriticalHitRate(),
+                preset.getEtc().getAttackIncrease(),
+                preset.getEtc().getSpeedIncrease()
+        );
+    }
+}

--- a/src/main/java/me/minkh/app/service/engraving/EngravingService.java
+++ b/src/main/java/me/minkh/app/service/engraving/EngravingService.java
@@ -15,7 +15,9 @@ import me.minkh.app.service.engraving.converter.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static me.minkh.app.service.LostArkConstants.*;
 
@@ -31,6 +33,8 @@ public class EngravingService {
 
     private final PresetRepository presetRepository;
     private final AccountRepository accountRepository;
+
+    private static final String INVALID_REQUEST_MESSAGE = "은 올바르지 않은 요청입니다.";
 
     public List<EngravingCalcResponse> calcEngravings(EngravingSetupRequest dto) {
         List<CombatAttributeDto> combatAttributeDtos = List.of(
@@ -70,7 +74,7 @@ public class EngravingService {
     @Transactional
     public EngravingPresetResponse savePreset(EngravingSetupRequest request, Long accountId) {
         Account account = accountRepository.findById(accountId)
-                .orElseThrow(() -> new IllegalArgumentException(accountId + "은 올바르지 않은 요청입니다."));
+                .orElseThrow(() -> new IllegalArgumentException(accountId + INVALID_REQUEST_MESSAGE));
 
         List<Preset> presets = this.presetRepository.findByAccount(account);
         if (presets.size() >= 5) {
@@ -81,6 +85,27 @@ public class EngravingService {
         entity.addAccount(account);
 
         Preset preset = this.presetRepository.save(entity);
+        return new EngravingPresetResponse(preset);
+    }
+
+    public List<EngravingPresetResponse> getPresets(Long accountId) {
+        Account account = this.accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException(accountId + INVALID_REQUEST_MESSAGE));
+
+        List<Preset> presets = this.presetRepository.findByAccount(account);
+
+        return presets.stream()
+                .map(EngravingPresetResponse::new)
+                .toList();
+    }
+
+    public EngravingPresetResponse getPreset(Long presetId, Long accountId) {
+        Account account = this.accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException(accountId + INVALID_REQUEST_MESSAGE));
+
+        Preset preset = this.presetRepository.findByIdAndAccount(presetId, account)
+                .orElseThrow(() -> new IllegalArgumentException(presetId + INVALID_REQUEST_MESSAGE));
+
         return new EngravingPresetResponse(preset);
     }
 }

--- a/src/main/java/me/minkh/app/service/engraving/EngravingService.java
+++ b/src/main/java/me/minkh/app/service/engraving/EngravingService.java
@@ -2,7 +2,8 @@ package me.minkh.app.service.engraving;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.domain.engraving.CombatAttribute;
-import me.minkh.app.domain.engraving.preset.*;
+import me.minkh.app.domain.engraving.preset.Preset;
+import me.minkh.app.domain.engraving.preset.PresetRepository;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.dto.engraving.request.EngravingDto;
 import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
@@ -26,8 +27,6 @@ public class EngravingService {
     private final EngravingsConverter engravingsConverter;
     private final EtcConverter etcConverter;
 
-    private final CombatStatRepository combatStatRepository;
-    private final EngravingRepository engravingRepository;
     private final PresetRepository presetRepository;
 
     public List<EngravingCalcResponse> calcEngravings(EngravingSetupRequest dto) {

--- a/src/main/java/me/minkh/app/service/engraving/EngravingService.java
+++ b/src/main/java/me/minkh/app/service/engraving/EngravingService.java
@@ -2,8 +2,8 @@ package me.minkh.app.service.engraving;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.domain.engraving.CombatAttribute;
-import me.minkh.app.dto.engraving.request.CalcEngravingRequest;
-import me.minkh.app.dto.engraving.response.CalcEngravingResponse;
+import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
+import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
 import me.minkh.app.dto.engraving.request.Engraving;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.service.engraving.converter.*;
@@ -23,7 +23,7 @@ public class EngravingService {
     private final EngravingsConverter engravingsConverter;
     private final EtcConverter etcConverter;
 
-    public List<CalcEngravingResponse> calcEngravings(CalcEngravingRequest dto) {
+    public List<EngravingCalcResponse> calcEngravings(EngravingSetupRequest dto) {
         List<CombatAttributeDto> combatAttributeDtos = List.of(
                 artifactConverter.convert(dto.getArtifact()),
                 elixirConverter.convert(dto.getElixir()),
@@ -40,9 +40,9 @@ public class EngravingService {
         double attackIncrease = this.getAttackIncrease(dto.getEngravings());
 
         return List.of(
-                new CalcEngravingResponse(SHARP_BLUNT, combatAttribute.calcSharpBlunt()),
-                new CalcEngravingResponse(BLITZ_COMMANDER, combatAttribute.calcBlitzCommander()),
-                new CalcEngravingResponse(CURSED_DOLL, combatAttribute.calcCursedDoll(attackIncrease))
+                new EngravingCalcResponse(SHARP_BLUNT, combatAttribute.calcSharpBlunt()),
+                new EngravingCalcResponse(BLITZ_COMMANDER, combatAttribute.calcBlitzCommander()),
+                new EngravingCalcResponse(CURSED_DOLL, combatAttribute.calcCursedDoll(attackIncrease))
         );
     }
 

--- a/src/main/java/me/minkh/app/service/engraving/EngravingService.java
+++ b/src/main/java/me/minkh/app/service/engraving/EngravingService.java
@@ -2,10 +2,10 @@ package me.minkh.app.service.engraving;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.domain.engraving.CombatAttribute;
+import me.minkh.app.dto.engraving.CombatAttributeDto;
+import me.minkh.app.dto.engraving.request.EngravingDto;
 import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
 import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
-import me.minkh.app.dto.engraving.request.Engraving;
-import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.service.engraving.converter.*;
 import org.springframework.stereotype.Service;
 
@@ -46,9 +46,9 @@ public class EngravingService {
         );
     }
 
-    private double getAttackIncrease(List<Engraving> engravings) {
+    private double getAttackIncrease(List<EngravingDto> engravings) {
         int level = 0;
-        for (Engraving engraving : engravings) {
+        for (EngravingDto engraving : engravings) {
             String name = engraving.getName();
             if (name.equals(CURSED_DOLL)) {
                 level = engraving.getLevel();

--- a/src/main/java/me/minkh/app/service/engraving/EngravingService.java
+++ b/src/main/java/me/minkh/app/service/engraving/EngravingService.java
@@ -2,12 +2,15 @@ package me.minkh.app.service.engraving;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.domain.engraving.CombatAttribute;
+import me.minkh.app.domain.engraving.preset.*;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import me.minkh.app.dto.engraving.request.EngravingDto;
 import me.minkh.app.dto.engraving.request.EngravingSetupRequest;
 import me.minkh.app.dto.engraving.response.EngravingCalcResponse;
+import me.minkh.app.dto.engraving.response.EngravingPresetResponse;
 import me.minkh.app.service.engraving.converter.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,6 +25,10 @@ public class EngravingService {
     private final CombatStatsConverter combatStatsConverter;
     private final EngravingsConverter engravingsConverter;
     private final EtcConverter etcConverter;
+
+    private final CombatStatRepository combatStatRepository;
+    private final EngravingRepository engravingRepository;
+    private final PresetRepository presetRepository;
 
     public List<EngravingCalcResponse> calcEngravings(EngravingSetupRequest dto) {
         List<CombatAttributeDto> combatAttributeDtos = List.of(
@@ -56,5 +63,11 @@ public class EngravingService {
             }
         }
         return CURSED_DOLL_TO_ATTACK_INCREASE_MAP.get(level);
+    }
+
+    @Transactional
+    public EngravingPresetResponse savePreset(EngravingSetupRequest request) {
+        Preset preset = this.presetRepository.save(request.toEntity());
+        return new EngravingPresetResponse(preset);
     }
 }

--- a/src/main/java/me/minkh/app/service/engraving/converter/CombatStatsConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/CombatStatsConverter.java
@@ -2,7 +2,7 @@ package me.minkh.app.service.engraving.converter;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.CombatStat;
+import me.minkh.app.dto.engraving.request.CombatStatDto;
 import me.minkh.app.service.engraving.converter.strategy.combatstats.CombatStatsConverterStrategy;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +14,9 @@ public class CombatStatsConverter {
 
     private final List<CombatStatsConverterStrategy> strategies;
 
-    public CombatAttributeDto convert(List<CombatStat> combatStats) {
+    public CombatAttributeDto convert(List<CombatStatDto> combatStats) {
         CombatAttributeDto result = new CombatAttributeDto();
-        for (CombatStat combatStat : combatStats) {
+        for (CombatStatDto combatStat : combatStats) {
             for (CombatStatsConverterStrategy strategy : strategies) {
                 if (!strategy.supports(combatStat.getType())) continue;
                 strategy.updateCombatAttributeDto(result, combatStat.getValue());

--- a/src/main/java/me/minkh/app/service/engraving/converter/ElixirConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/ElixirConverter.java
@@ -2,7 +2,7 @@ package me.minkh.app.service.engraving.converter;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.Elixir;
+import me.minkh.app.dto.engraving.request.ElixirDto;
 import me.minkh.app.service.engraving.converter.strategy.elixir.ElixirConverterStrategy;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +16,7 @@ public class ElixirConverter {
 
     private final List<ElixirConverterStrategy> strategies;
 
-    public CombatAttributeDto convert(Elixir elixir) {
+    public CombatAttributeDto convert(ElixirDto elixir) {
         CombatAttributeDto result = new CombatAttributeDto();
         int headOffensePower = elixir.getHeadOffensePower();
         result.setAttackIncrease(ELIXIR_TO_ATTACK_INCREASE_MAP.get(headOffensePower));

--- a/src/main/java/me/minkh/app/service/engraving/converter/EngravingsConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/EngravingsConverter.java
@@ -2,7 +2,7 @@ package me.minkh.app.service.engraving.converter;
 
 import lombok.RequiredArgsConstructor;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.Engraving;
+import me.minkh.app.dto.engraving.request.EngravingDto;
 import me.minkh.app.service.engraving.converter.strategy.engravings.EngravingsConverterStrategy;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +14,9 @@ public class EngravingsConverter {
 
     private final List<EngravingsConverterStrategy> strategies;
 
-    public CombatAttributeDto convert(List<Engraving> engravings) {
+    public CombatAttributeDto convert(List<EngravingDto> engravings) {
         CombatAttributeDto result = new CombatAttributeDto();
-        for (Engraving engraving : engravings) {
+        for (EngravingDto engraving : engravings) {
             for (EngravingsConverterStrategy strategy : this.strategies) {
                 if (!strategy.supports(engraving.getName())) continue;
                 strategy.updateCombatAttributeDto(result, engraving.getLevel());

--- a/src/main/java/me/minkh/app/service/engraving/converter/EtcConverter.java
+++ b/src/main/java/me/minkh/app/service/engraving/converter/EtcConverter.java
@@ -1,13 +1,13 @@
 package me.minkh.app.service.engraving.converter;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.Etc;
+import me.minkh.app.dto.engraving.request.EtcDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EtcConverter {
 
-    public CombatAttributeDto convert(Etc etc) {
+    public CombatAttributeDto convert(EtcDto etc) {
         return new CombatAttributeDto(
                 etc.getCriticalHitRate(),
                 etc.getCriticalDamage(),

--- a/src/test/java/me/minkh/app/service/engraving/EngravingServiceTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/EngravingServiceTest.java
@@ -1,0 +1,64 @@
+package me.minkh.app.service.engraving;
+
+import me.minkh.app.domain.engraving.preset.PresetRepository;
+import me.minkh.app.dto.engraving.request.*;
+import me.minkh.app.dto.engraving.response.EngravingPresetResponse;
+import me.minkh.app.service.LostArkConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class EngravingServiceTest {
+
+    @Autowired
+    PresetRepository presetRepository;
+
+    @Autowired
+    EngravingService engravingService;
+
+    @AfterEach
+    void afterEach() {
+        presetRepository.deleteAll();
+    }
+
+    @DisplayName("프리셋 저장에 성공하는 테스트")
+    @Test
+    void savePreset() {
+        // given
+        String artifact = LostArkConstants.NIGHTMARE;
+        ElixirDto elixirDto = new ElixirDto(LostArkConstants.EXPERT, 35, 5);
+        EtcDto etcDto = new EtcDto(30.0, 2.1, 11.3, 5.4);
+        List<CombatStatDto> combatStatDtos = List.of(
+                new CombatStatDto(LostArkConstants.CRITICAL, 650),
+                new CombatStatDto(LostArkConstants.SWIFTNESS, 1650));
+        List<EngravingDto> engravingDtos = List.of(new EngravingDto(LostArkConstants.CURSED_DOLL, 3),
+                new EngravingDto(LostArkConstants.ADRENALINE, 3));
+
+        EngravingSetupRequest request = EngravingSetupRequest.builder()
+                .artifact(artifact)
+                .elixir(elixirDto)
+                .etc(etcDto)
+                .combatStats(combatStatDtos)
+                .engravings(engravingDtos)
+                .build();
+
+        // when
+        EngravingPresetResponse response = this.engravingService.savePreset(request);
+
+        // then
+        assertThat(response.getArtifact()).isEqualTo(artifact);
+        assertThat(response.getElixir().getType()).isEqualTo(LostArkConstants.EXPERT);
+        assertThat(response.getEtc().getAttackIncrease()).isEqualTo(11.3);
+        assertThat(response.getCombatStats().size()).isEqualTo(2);
+        assertThat(response.getEngravings().size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/me/minkh/app/service/engraving/converter/CombatStatsConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/CombatStatsConverterTest.java
@@ -1,7 +1,7 @@
 package me.minkh.app.service.engraving.converter;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.CombatStat;
+import me.minkh.app.dto.engraving.request.CombatStatDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +23,7 @@ class CombatStatsConverterTest {
     @Test
     void test() {
         // given
-        List<CombatStat> combatStats = List.of(new CombatStat("치명", 1_000));
+        List<CombatStatDto> combatStats = List.of(new CombatStatDto("치명", 1_000));
 
         // when
         CombatAttributeDto combatAttributeDto = combatStatsConverter.convert(combatStats);
@@ -36,7 +36,7 @@ class CombatStatsConverterTest {
     @Test
     void test2() {
         // given
-        List<CombatStat> combatStats = List.of(new CombatStat("신속", 1_000));
+        List<CombatStatDto> combatStats = List.of(new CombatStatDto("신속", 1_000));
 
         // when
         CombatAttributeDto combatAttributeDto = combatStatsConverter.convert(combatStats);
@@ -49,9 +49,9 @@ class CombatStatsConverterTest {
     @Test
     void test3() {
         // given
-        List<CombatStat> combatStats = List.of(
-                new CombatStat("치명", 1_000),
-                new CombatStat("신속", 1_000));
+        List<CombatStatDto> combatStats = List.of(
+                new CombatStatDto("치명", 1_000),
+                new CombatStatDto("신속", 1_000));
 
         // when
         CombatAttributeDto combatAttributeDto = combatStatsConverter.convert(combatStats);
@@ -64,9 +64,9 @@ class CombatStatsConverterTest {
     @Test
     void test4() {
         // given
-        List<CombatStat> combatStats = List.of(
-                new CombatStat("이상한 값1", 1_000),
-                new CombatStat("이상한 값2", 1_000));
+        List<CombatStatDto> combatStats = List.of(
+                new CombatStatDto("이상한 값1", 1_000),
+                new CombatStatDto("이상한 값2", 1_000));
 
         // when
         CombatAttributeDto combatAttributeDto = combatStatsConverter.convert(combatStats);

--- a/src/test/java/me/minkh/app/service/engraving/converter/ElixirConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/ElixirConverterTest.java
@@ -1,6 +1,6 @@
 package me.minkh.app.service.engraving.converter;
 
-import me.minkh.app.dto.engraving.request.Elixir;
+import me.minkh.app.dto.engraving.request.ElixirDto;
 import me.minkh.app.dto.engraving.CombatAttributeDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ class ElixirConverterTest {
 
     void extracted(int headOffensePower, double attackIncrease) {
         // given
-        Elixir elixir = new Elixir("회심", 0, headOffensePower);
+        ElixirDto elixir = new ElixirDto("회심", 0, headOffensePower);
 
         // when
         CombatAttributeDto combatAttributeDto = elixirConverter.convert(elixir);
@@ -43,7 +43,7 @@ class ElixirConverterTest {
     @Test
     void vanguard35() {
         // given
-        Elixir elixir = new Elixir("선봉대", 35, 3);
+        ElixirDto elixir = new ElixirDto("선봉대", 35, 3);
 
         // when
         CombatAttributeDto combatAttributeDto = elixirConverter.convert(elixir);
@@ -56,7 +56,7 @@ class ElixirConverterTest {
     @Test
     void vanguard40() {
         // given
-        Elixir elixir = new Elixir("선봉대", 40, 5);
+        ElixirDto elixir = new ElixirDto("선봉대", 40, 5);
 
         // when
         CombatAttributeDto combatAttributeDto = elixirConverter.convert(elixir);
@@ -69,7 +69,7 @@ class ElixirConverterTest {
     @Test
     void expert35() {
         // given
-        Elixir elixir = new Elixir("달인", 35, 3);
+        ElixirDto elixir = new ElixirDto("달인", 35, 3);
 
         // when
         CombatAttributeDto combatAttributeDto = elixirConverter.convert(elixir);
@@ -83,7 +83,7 @@ class ElixirConverterTest {
     @Test
     void expert40() {
         // given
-        Elixir elixir = new Elixir("달인", 40, 3);
+        ElixirDto elixir = new ElixirDto("달인", 40, 3);
 
         // when
         CombatAttributeDto combatAttributeDto = elixirConverter.convert(elixir);

--- a/src/test/java/me/minkh/app/service/engraving/converter/EngravingsConverterTest.java
+++ b/src/test/java/me/minkh/app/service/engraving/converter/EngravingsConverterTest.java
@@ -1,7 +1,7 @@
 package me.minkh.app.service.engraving.converter;
 
 import me.minkh.app.dto.engraving.CombatAttributeDto;
-import me.minkh.app.dto.engraving.request.Engraving;
+import me.minkh.app.dto.engraving.request.EngravingDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,7 +30,7 @@ class EngravingsConverterTest {
     @DisplayName("저주받은 인형 0, 아드레날린 0 = 0.0")
     void test(int cursedDollLevel, int adrenalineLevel, double expectedAttackIncrease) {
         // given
-        List<Engraving> engravings = getEngravings(cursedDollLevel, adrenalineLevel);
+        List<EngravingDto> engravings = getEngravings(cursedDollLevel, adrenalineLevel);
 
         // when
         CombatAttributeDto combatAttributeDto = engravingsConverter.convert(engravings);
@@ -44,7 +44,7 @@ class EngravingsConverterTest {
     @DisplayName("아드레날린 레벨에 따른 치명타 적중률")
     void test2(int level) {
         // given
-        List<Engraving> engravings = getEngravings(0, level);
+        List<EngravingDto> engravings = getEngravings(0, level);
 
         // when
         CombatAttributeDto combatAttributeDto = engravingsConverter.convert(engravings);
@@ -78,7 +78,7 @@ class EngravingsConverterTest {
         );
     }
 
-    private List<Engraving> getEngravings(int adrenalineLevel, int expectedAttackIncrease) {
-        return List.of(new Engraving(CURSED_DOLL, adrenalineLevel), new Engraving(ADRENALINE, expectedAttackIncrease));
+    private List<EngravingDto> getEngravings(int adrenalineLevel, int expectedAttackIncrease) {
+        return List.of(new EngravingDto(CURSED_DOLL, adrenalineLevel), new EngravingDto(ADRENALINE, expectedAttackIncrease));
     }
 }


### PR DESCRIPTION
이 전의 Session 동기화를 위한 PR이 너무 내용이 없는 것 같아 새롭게 PR을 생성하였습니다.

로드밸런서(Nginx) 설치 이후 2개의 서버를 띄워 라우팅 테스트를 해보았습니다.

이에 인증 객체를 공유하지 못하는 문제를 파악하였습니다.

따라서, 공유할 수 있는 세션 저장소를 생성하기로 하였습니다.

- 스프링 세션 의존성 추가
- 직렬화를 위한 BaseEntity 수정

및

- 프리셋 기능을 구현하였습니다. 기능에 대한 자세한 내용은 이슈[#37]에 작성하였습니다.