### PR TITLE
API 요청 제한 - Rate Limit 구현

### DIFF
--- a/src/main/java/me/minkh/app/controller/InfoController.java
+++ b/src/main/java/me/minkh/app/controller/InfoController.java
@@ -1,8 +1,11 @@
 package me.minkh.app.controller;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.minkh.app.config.auth.CurrentId;
 import me.minkh.app.dto.info.InfoResponse;
+import me.minkh.app.exception.TooManyRequestsException;
+import me.minkh.app.service.RateLimitService;
 import me.minkh.app.service.info.InfoService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,19 +13,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 public class InfoController {
 
     private final InfoService infoService;
-
-    public InfoController(InfoService homeService) {
-        this.infoService = homeService;
-    }
+    private final RateLimitService rateLimitService;
 
     @GetMapping("/info/{characterName}")
     public InfoResponse info(
             @PathVariable("characterName") String characterName,
             @CurrentId Long accountId
     ) {
+        if (rateLimitService.isLimit(accountId.toString())) {
+            throw new TooManyRequestsException("너무 많은 요청을 보냈습니다. 잠시 대기해 주세요.");
+        }
         return this.infoService.info(characterName, accountId);
     }
 }

--- a/src/main/java/me/minkh/app/exception/TooManyRequestsException.java
+++ b/src/main/java/me/minkh/app/exception/TooManyRequestsException.java
@@ -1,0 +1,8 @@
+package me.minkh.app.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/me/minkh/app/exception/advice/ControllerAdvice.java
+++ b/src/main/java/me/minkh/app/exception/advice/ControllerAdvice.java
@@ -3,6 +3,7 @@ package me.minkh.app.exception.advice;
 import lombok.extern.slf4j.Slf4j;
 import me.minkh.app.exception.CharacterNotFoundException;
 import me.minkh.app.exception.ErrorResponse;
+import me.minkh.app.exception.TooManyRequestsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -19,6 +20,12 @@ public class ControllerAdvice {
     public ResponseEntity<ErrorResponse> runtimeExceptionHandler(RuntimeException e) {
         log.error("runtimeExceptionHandler", e);
         return this.exceptionHandler(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(TooManyRequestsException.class)
+    public ResponseEntity<ErrorResponse> tooManyRequestsExceptionHandler(TooManyRequestsException e) {
+        log.error("tooManyRequestsExceptionHandler", e);
+        return this.exceptionHandler(e, HttpStatus.TOO_MANY_REQUESTS, e.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/me/minkh/app/service/RateLimitService.java
+++ b/src/main/java/me/minkh/app/service/RateLimitService.java
@@ -1,0 +1,31 @@
+package me.minkh.app.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RateLimitService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final int MAX_REQUEST = 33;
+    private static final int TIMEOUT = 1;
+
+    public boolean isLimit(String key) {
+        ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
+        Long count = valueOps.increment(key);
+        if (count == null) {
+            throw new IllegalArgumentException(key + "는 올바르지 않은 요청입니다.");
+        }
+        if (count == 1) {
+            redisTemplate.expire(key, TIMEOUT, TimeUnit.MINUTES);
+        }
+        return count > MAX_REQUEST;
+    }
+}

--- a/src/main/java/me/minkh/app/service/RateLimitService.java
+++ b/src/main/java/me/minkh/app/service/RateLimitService.java
@@ -20,6 +20,7 @@ public class RateLimitService {
     public boolean isLimit(String key) {
         ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
         Long count = valueOps.increment(key);
+        log.info("count = {}", count);
         if (count == null) {
             throw new IllegalArgumentException(key + "는 올바르지 않은 요청입니다.");
         }


### PR DESCRIPTION
## 목표

- GET /info/characterName API를 1분에 33회 이상 호출하면 429 에러가 나타난다.
- 1분이 지나지 않았는데 계속 요청을 보내면 응답을 무한히 받을 수 없으므로 API 호출을 제한시키는 기능을 추가한다.
